### PR TITLE
Fix type checking dependencies in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ test = [
     "pytest-homeassistant-custom-component>=0.13.285",
 ]
 dev = [
+    "hass-ufh-controller[test]",
     "ruff>=0.14.10",
     "ty>=0.0.1a11",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1247,6 +1247,10 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-homeassistant-custom-component" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1260,6 +1264,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "colorlog", specifier = ">=6.10.1" },
+    { name = "hass-ufh-controller", extras = ["test"], marker = "extra == 'dev'" },
     { name = "homeassistant", specifier = ">=2025.10.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.20.0" },


### PR DESCRIPTION
The type check CI job installs --extra dev but the test files import pytest and pytest_homeassistant_custom_component. By including the test extra in dev, the type checker can resolve all imports properly.