### PR TITLE
Expose presets in config flow UI

### DIFF
--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -112,6 +112,7 @@ def get_zone_schema(
     defaults = defaults or {}
     setpoint = defaults.get("setpoint", DEFAULT_SETPOINT)
     pid = defaults.get("pid", DEFAULT_PID)
+    presets = defaults.get("presets", {})
 
     return vol.Schema(
         {
@@ -196,6 +197,61 @@ def get_zone_schema(
                     mode=selector.NumberSelectorMode.BOX,
                 )
             ),
+            # Preset setpoints - leave empty to disable a preset
+            vol.Optional(
+                "preset_comfort",
+                description={
+                    "suggested_value": presets.get("comfort", {}).get("setpoint")
+                },
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=5,
+                    max=35,
+                    step=0.5,
+                    unit_of_measurement="°C",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(
+                "preset_eco",
+                description={"suggested_value": presets.get("eco", {}).get("setpoint")},
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=5,
+                    max=35,
+                    step=0.5,
+                    unit_of_measurement="°C",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(
+                "preset_away",
+                description={
+                    "suggested_value": presets.get("away", {}).get("setpoint")
+                },
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=5,
+                    max=35,
+                    step=0.5,
+                    unit_of_measurement="°C",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(
+                "preset_boost",
+                description={
+                    "suggested_value": presets.get("boost", {}).get("setpoint")
+                },
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=5,
+                    max=35,
+                    step=0.5,
+                    unit_of_measurement="°C",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
         }
     )
 
@@ -203,6 +259,21 @@ def get_zone_schema(
 def build_zone_data(user_input: dict[str, Any]) -> dict[str, Any]:
     """Build zone data from user input."""
     zone_id = user_input.get("zone_id") or slugify(user_input["name"])
+
+    # Build presets from user input - only include if setpoint is provided
+    presets: dict[str, dict[str, Any]] = {}
+    if user_input.get("preset_comfort") is not None:
+        presets["comfort"] = {"setpoint": user_input["preset_comfort"]}
+    if user_input.get("preset_eco") is not None:
+        presets["eco"] = {"setpoint": user_input["preset_eco"]}
+    if user_input.get("preset_away") is not None:
+        presets["away"] = {"setpoint": user_input["preset_away"]}
+    if user_input.get("preset_boost") is not None:
+        presets["boost"] = {
+            "setpoint": user_input["preset_boost"],
+            "pid_enabled": False,
+        }
+
     return {
         "id": zone_id,
         "name": user_input["name"],
@@ -223,7 +294,7 @@ def build_zone_data(user_input: dict[str, Any]) -> dict[str, Any]:
             "integral_min": DEFAULT_PID["integral_min"],
             "integral_max": DEFAULT_PID["integral_max"],
         },
-        "presets": {},
+        "presets": presets,
     }
 
 

--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -57,5 +57,13 @@ DEFAULT_SETPOINT = {
     "default": 21.0,
 }
 
+# Default preset configuration
+DEFAULT_PRESETS = {
+    "comfort": {"setpoint": 22.0},
+    "eco": {"setpoint": 19.0},
+    "away": {"setpoint": 16.0},
+    "boost": {"setpoint": 25.0, "pid_enabled": False},
+}
+
 # Controller loop interval in seconds
 CONTROLLER_LOOP_INTERVAL = 60

--- a/custom_components/ufh_controller/strings.json
+++ b/custom_components/ufh_controller/strings.json
@@ -80,7 +80,17 @@
             "setpoint_default": "Default setpoint",
             "kp": "PID proportional gain (Kp)",
             "ki": "PID integral gain (Ki)",
-            "kd": "PID derivative gain (Kd)"
+            "kd": "PID derivative gain (Kd)",
+            "preset_comfort": "Comfort preset setpoint",
+            "preset_eco": "Eco preset setpoint",
+            "preset_away": "Away preset setpoint",
+            "preset_boost": "Boost preset setpoint"
+          },
+          "data_description": {
+            "preset_comfort": "Leave empty to disable this preset",
+            "preset_eco": "Leave empty to disable this preset",
+            "preset_away": "Leave empty to disable this preset",
+            "preset_boost": "Leave empty to disable this preset. Boost mode disables PID control."
           }
         },
         "reconfigure": {
@@ -97,7 +107,17 @@
             "setpoint_default": "Default setpoint",
             "kp": "PID proportional gain (Kp)",
             "ki": "PID integral gain (Ki)",
-            "kd": "PID derivative gain (Kd)"
+            "kd": "PID derivative gain (Kd)",
+            "preset_comfort": "Comfort preset setpoint",
+            "preset_eco": "Eco preset setpoint",
+            "preset_away": "Away preset setpoint",
+            "preset_boost": "Boost preset setpoint"
+          },
+          "data_description": {
+            "preset_comfort": "Leave empty to disable this preset",
+            "preset_eco": "Leave empty to disable this preset",
+            "preset_away": "Leave empty to disable this preset",
+            "preset_boost": "Leave empty to disable this preset. Boost mode disables PID control."
           }
         }
       },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -619,3 +619,47 @@ def test_build_zone_data_with_all_values() -> None:
     assert result["pid"]["kp"] == 60.0
     assert result["pid"]["ki"] == 0.1
     assert result["pid"]["kd"] == 0.5
+
+
+def test_build_zone_data_with_presets() -> None:
+    """Test building zone data with preset values provided."""
+    user_input: dict[str, Any] = {
+        "name": "Preset Zone",
+        "temp_sensor": "sensor.preset_temp",
+        "valve_switch": "switch.preset_valve",
+        "preset_comfort": 22.0,
+        "preset_eco": 19.0,
+        "preset_away": 16.0,
+        "preset_boost": 25.0,
+    }
+
+    result = build_zone_data(user_input)
+
+    assert result["presets"] == {
+        "comfort": {"setpoint": 22.0},
+        "eco": {"setpoint": 19.0},
+        "away": {"setpoint": 16.0},
+        "boost": {"setpoint": 25.0, "pid_enabled": False},
+    }
+
+
+def test_build_zone_data_with_partial_presets() -> None:
+    """Test building zone data with only some preset values provided."""
+    user_input: dict[str, Any] = {
+        "name": "Partial Preset Zone",
+        "temp_sensor": "sensor.partial_temp",
+        "valve_switch": "switch.partial_valve",
+        "preset_comfort": 22.0,
+        "preset_boost": 28.0,
+        # eco and away not provided - should not appear in presets
+    }
+
+    result = build_zone_data(user_input)
+
+    assert result["presets"] == {
+        "comfort": {"setpoint": 22.0},
+        "boost": {"setpoint": 28.0, "pid_enabled": False},
+    }
+    # Verify that eco and away are not in presets
+    assert "eco" not in result["presets"]
+    assert "away" not in result["presets"]


### PR DESCRIPTION
Add preset fields (comfort, eco, away, boost) to the zone configuration flow. Users can now configure preset setpoints when adding or editing zones. Each preset is optional - leaving a field empty disables that preset. Boost mode automatically disables PID control as per spec.