### PR TITLE
Extract magic numbers to constants file

### DIFF
--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -23,6 +23,17 @@ from .const import (
     LOGGER,
     SUBENTRY_TYPE_CONTROLLER,
     SUBENTRY_TYPE_ZONE,
+    UI_SETPOINT_DEFAULT,
+    UI_SETPOINT_MAX,
+    UI_SETPOINT_MIN,
+    UI_TIMING_CLOSING_WARNING,
+    UI_TIMING_CONTROLLER_LOOP_INTERVAL,
+    UI_TIMING_DUTY_CYCLE_WINDOW,
+    UI_TIMING_MIN_RUN_TIME,
+    UI_TIMING_OBSERVATION_PERIOD,
+    UI_TIMING_VALVE_OPEN_TIME,
+    UI_TIMING_WINDOW_BLOCK_THRESHOLD,
+    TimingDefaults,
 )
 
 CONF_NAME = "name"
@@ -33,7 +44,7 @@ CONF_CIRCULATION_ENTITY = "circulation_entity"
 CONF_SUMMER_MODE_ENTITY = "summer_mode_entity"
 
 
-def get_timing_schema(timing: dict[str, Any] | None = None) -> vol.Schema:
+def get_timing_schema(timing: TimingDefaults | None = None) -> vol.Schema:
     """Get the schema for timing configuration."""
     timing = timing or DEFAULT_TIMING
     return vol.Schema(
@@ -45,7 +56,10 @@ def get_timing_schema(timing: dict[str, Any] | None = None) -> vol.Schema:
                 ),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=1800, max=14400, step=600, unit_of_measurement="s"
+                    min=UI_TIMING_OBSERVATION_PERIOD["min"],
+                    max=UI_TIMING_OBSERVATION_PERIOD["max"],
+                    step=UI_TIMING_OBSERVATION_PERIOD["step"],
+                    unit_of_measurement="s",
                 )
             ),
             vol.Required(
@@ -55,7 +69,10 @@ def get_timing_schema(timing: dict[str, Any] | None = None) -> vol.Schema:
                 ),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=600, max=7200, step=300, unit_of_measurement="s"
+                    min=UI_TIMING_DUTY_CYCLE_WINDOW["min"],
+                    max=UI_TIMING_DUTY_CYCLE_WINDOW["max"],
+                    step=UI_TIMING_DUTY_CYCLE_WINDOW["step"],
+                    unit_of_measurement="s",
                 )
             ),
             vol.Required(
@@ -63,7 +80,10 @@ def get_timing_schema(timing: dict[str, Any] | None = None) -> vol.Schema:
                 default=timing.get("min_run_time", DEFAULT_TIMING["min_run_time"]),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=60, max=1800, step=60, unit_of_measurement="s"
+                    min=UI_TIMING_MIN_RUN_TIME["min"],
+                    max=UI_TIMING_MIN_RUN_TIME["max"],
+                    step=UI_TIMING_MIN_RUN_TIME["step"],
+                    unit_of_measurement="s",
                 )
             ),
             vol.Required(
@@ -73,7 +93,10 @@ def get_timing_schema(timing: dict[str, Any] | None = None) -> vol.Schema:
                 ),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=60, max=600, step=30, unit_of_measurement="s"
+                    min=UI_TIMING_VALVE_OPEN_TIME["min"],
+                    max=UI_TIMING_VALVE_OPEN_TIME["max"],
+                    step=UI_TIMING_VALVE_OPEN_TIME["step"],
+                    unit_of_measurement="s",
                 )
             ),
             vol.Required(
@@ -84,7 +107,10 @@ def get_timing_schema(timing: dict[str, Any] | None = None) -> vol.Schema:
                 ),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=60, max=600, step=30, unit_of_measurement="s"
+                    min=UI_TIMING_CLOSING_WARNING["min"],
+                    max=UI_TIMING_CLOSING_WARNING["max"],
+                    step=UI_TIMING_CLOSING_WARNING["step"],
+                    unit_of_measurement="s",
                 )
             ),
             vol.Required(
@@ -95,9 +121,9 @@ def get_timing_schema(timing: dict[str, Any] | None = None) -> vol.Schema:
                 ),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=0,
-                    max=1,
-                    step=0.01,
+                    min=UI_TIMING_WINDOW_BLOCK_THRESHOLD["min"],
+                    max=UI_TIMING_WINDOW_BLOCK_THRESHOLD["max"],
+                    step=UI_TIMING_WINDOW_BLOCK_THRESHOLD["step"],
                     mode=selector.NumberSelectorMode.BOX,
                 )
             ),
@@ -109,7 +135,10 @@ def get_timing_schema(timing: dict[str, Any] | None = None) -> vol.Schema:
                 ),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=10, max=300, step=5, unit_of_measurement="s"
+                    min=UI_TIMING_CONTROLLER_LOOP_INTERVAL["min"],
+                    max=UI_TIMING_CONTROLLER_LOOP_INTERVAL["max"],
+                    step=UI_TIMING_CONTROLLER_LOOP_INTERVAL["step"],
+                    unit_of_measurement="s",
                 )
             ),
         }
@@ -155,9 +184,9 @@ def get_zone_schema(
                 default=setpoint.get("min", DEFAULT_SETPOINT["min"]),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=5,
-                    max=30,
-                    step=0.1,
+                    min=UI_SETPOINT_MIN["min"],
+                    max=UI_SETPOINT_MIN["max"],
+                    step=UI_SETPOINT_MIN["step"],
                     unit_of_measurement="°C",
                     mode=selector.NumberSelectorMode.SLIDER,
                 )
@@ -167,9 +196,9 @@ def get_zone_schema(
                 default=setpoint.get("max", DEFAULT_SETPOINT["max"]),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=5,
-                    max=35,
-                    step=0.1,
+                    min=UI_SETPOINT_MAX["min"],
+                    max=UI_SETPOINT_MAX["max"],
+                    step=UI_SETPOINT_MAX["step"],
                     unit_of_measurement="°C",
                     mode=selector.NumberSelectorMode.SLIDER,
                 )
@@ -179,9 +208,9 @@ def get_zone_schema(
                 default=setpoint.get("default", DEFAULT_SETPOINT["default"]),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=5,
-                    max=35,
-                    step=0.1,
+                    min=UI_SETPOINT_DEFAULT["min"],
+                    max=UI_SETPOINT_DEFAULT["max"],
+                    step=UI_SETPOINT_DEFAULT["step"],
                     unit_of_measurement="°C",
                     mode=selector.NumberSelectorMode.SLIDER,
                 )
@@ -330,10 +359,12 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> config_entries.ConfigFlowResult:
         """Configure timing parameters."""
         # Get timing from controller subentry if it exists
-        timing = DEFAULT_TIMING.copy()
+        timing: TimingDefaults = DEFAULT_TIMING.copy()
         for subentry in self.config_entry.subentries.values():
             if subentry.subentry_type == SUBENTRY_TYPE_CONTROLLER:
-                timing = subentry.data.get("timing", DEFAULT_TIMING)
+                stored = subentry.data.get("timing")
+                if stored is not None:
+                    timing = stored  # type: ignore[assignment]
                 break
 
         if user_input is not None:

--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -2,6 +2,7 @@
 
 from enum import StrEnum
 from logging import Logger, getLogger
+from typing import TypedDict
 
 LOGGER: Logger = getLogger(__package__)
 
@@ -30,8 +31,39 @@ class OperationMode(StrEnum):
     DISABLED = "disabled"
 
 
+class TimingDefaults(TypedDict):
+    """Type for DEFAULT_TIMING dictionary."""
+
+    observation_period: int
+    duty_cycle_window: int
+    min_run_time: int
+    valve_open_time: int
+    closing_warning_duration: int
+    window_block_threshold: float
+    controller_loop_interval: int
+
+
+class PIDDefaults(TypedDict):
+    """Type for DEFAULT_PID dictionary."""
+
+    kp: float
+    ki: float
+    kd: float
+    integral_min: float
+    integral_max: float
+
+
+class SetpointDefaults(TypedDict):
+    """Type for DEFAULT_SETPOINT dictionary."""
+
+    min: float
+    max: float
+    step: float
+    default: float
+
+
 # Default timing parameters (in seconds unless otherwise noted)
-DEFAULT_TIMING = {
+DEFAULT_TIMING: TimingDefaults = {
     "observation_period": 7200,  # 2 hours
     "duty_cycle_window": 3600,  # 1 hour
     "min_run_time": 540,  # 9 minutes
@@ -42,7 +74,7 @@ DEFAULT_TIMING = {
 }
 
 # Default PID controller parameters
-DEFAULT_PID = {
+DEFAULT_PID: PIDDefaults = {
     "kp": 50.0,
     "ki": 0.001,
     "kd": 0.0,
@@ -51,9 +83,32 @@ DEFAULT_PID = {
 }
 
 # Default setpoint configuration
-DEFAULT_SETPOINT = {
+DEFAULT_SETPOINT: SetpointDefaults = {
     "min": 16.0,
     "max": 28.0,
     "step": 0.5,
     "default": 21.0,
 }
+
+# Cycle mode configuration
+DEFAULT_CYCLE_MODE_HOURS = 8
+
+# Zone operation thresholds
+DEFAULT_VALVE_OPEN_THRESHOLD = 0.85  # 85% threshold for considering valve fully open
+
+# Window centering for duty cycle calculation
+DEFAULT_WINDOW_CENTER_MINUTE = 30
+
+# UI validation constraints for timing parameters
+UI_TIMING_OBSERVATION_PERIOD = {"min": 1800, "max": 14400, "step": 600}
+UI_TIMING_DUTY_CYCLE_WINDOW = {"min": 600, "max": 7200, "step": 300}
+UI_TIMING_MIN_RUN_TIME = {"min": 60, "max": 1800, "step": 60}
+UI_TIMING_VALVE_OPEN_TIME = {"min": 60, "max": 600, "step": 30}
+UI_TIMING_CLOSING_WARNING = {"min": 60, "max": 600, "step": 30}
+UI_TIMING_WINDOW_BLOCK_THRESHOLD = {"min": 0, "max": 1, "step": 0.01}
+UI_TIMING_CONTROLLER_LOOP_INTERVAL = {"min": 10, "max": 300, "step": 5}
+
+# UI validation constraints for setpoint parameters
+UI_SETPOINT_MIN = {"min": 5.0, "max": 30.0, "step": 0.1}
+UI_SETPOINT_MAX = {"min": 5.0, "max": 35.0, "step": 0.1}
+UI_SETPOINT_DEFAULT = {"min": 5.0, "max": 35.0, "step": 0.1}

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -9,6 +9,10 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
+    DEFAULT_PID,
+    DEFAULT_SETPOINT,
+    DEFAULT_TIMING,
+    DEFAULT_VALVE_OPEN_THRESHOLD,
     DOMAIN,
     LOGGER,
     SUBENTRY_TYPE_CONTROLLER,
@@ -27,7 +31,7 @@ from .core import (
     get_valve_open_window,
     get_window_open_average,
 )
-from .core.zone import _VALVE_OPEN_THRESHOLD, CircuitType
+from .core.zone import CircuitType
 
 # Storage constants
 STORAGE_VERSION = 1
@@ -87,13 +91,27 @@ class UFHControllerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             timing_opts = entry.options.get("timing", {})
 
         timing = TimingParams(
-            observation_period=timing_opts.get("observation_period", 7200),
-            duty_cycle_window=timing_opts.get("duty_cycle_window", 3600),
-            min_run_time=timing_opts.get("min_run_time", 540),
-            valve_open_time=timing_opts.get("valve_open_time", 210),
-            closing_warning_duration=timing_opts.get("closing_warning_duration", 240),
-            window_block_threshold=timing_opts.get("window_block_threshold", 0.05),
-            controller_loop_interval=timing_opts.get("controller_loop_interval", 60),
+            observation_period=timing_opts.get(
+                "observation_period", DEFAULT_TIMING["observation_period"]
+            ),
+            duty_cycle_window=timing_opts.get(
+                "duty_cycle_window", DEFAULT_TIMING["duty_cycle_window"]
+            ),
+            min_run_time=timing_opts.get(
+                "min_run_time", DEFAULT_TIMING["min_run_time"]
+            ),
+            valve_open_time=timing_opts.get(
+                "valve_open_time", DEFAULT_TIMING["valve_open_time"]
+            ),
+            closing_warning_duration=timing_opts.get(
+                "closing_warning_duration", DEFAULT_TIMING["closing_warning_duration"]
+            ),
+            window_block_threshold=timing_opts.get(
+                "window_block_threshold", DEFAULT_TIMING["window_block_threshold"]
+            ),
+            controller_loop_interval=timing_opts.get(
+                "controller_loop_interval", DEFAULT_TIMING["controller_loop_interval"]
+            ),
         )
 
         # Build zones from subentries
@@ -113,14 +131,20 @@ class UFHControllerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     valve_switch=zone_data["valve_switch"],
                     circuit_type=CircuitType(zone_data.get("circuit_type", "regular")),
                     window_sensors=zone_data.get("window_sensors", []),
-                    setpoint_min=setpoint_opts.get("min", 16.0),
-                    setpoint_max=setpoint_opts.get("max", 28.0),
-                    setpoint_default=setpoint_opts.get("default", 21.0),
-                    kp=pid_opts.get("kp", 50.0),
-                    ki=pid_opts.get("ki", 0.05),
-                    kd=pid_opts.get("kd", 0.0),
-                    integral_min=pid_opts.get("integral_min", 0.0),
-                    integral_max=pid_opts.get("integral_max", 100.0),
+                    setpoint_min=setpoint_opts.get("min", DEFAULT_SETPOINT["min"]),
+                    setpoint_max=setpoint_opts.get("max", DEFAULT_SETPOINT["max"]),
+                    setpoint_default=setpoint_opts.get(
+                        "default", DEFAULT_SETPOINT["default"]
+                    ),
+                    kp=pid_opts.get("kp", DEFAULT_PID["kp"]),
+                    ki=pid_opts.get("ki", DEFAULT_PID["ki"]),
+                    kd=pid_opts.get("kd", DEFAULT_PID["kd"]),
+                    integral_min=pid_opts.get(
+                        "integral_min", DEFAULT_PID["integral_min"]
+                    ),
+                    integral_max=pid_opts.get(
+                        "integral_max", DEFAULT_PID["integral_max"]
+                    ),
                 )
             )
 
@@ -438,7 +462,7 @@ class UFHControllerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "window_blocked": state.window_open_avg
                     > self._controller.config.timing.window_block_threshold,
                     "is_requesting_heat": state.valve_on
-                    and state.open_state_avg >= _VALVE_OPEN_THRESHOLD,
+                    and state.open_state_avg >= DEFAULT_VALVE_OPEN_THRESHOLD,
                 }
 
         return result

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -10,6 +10,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+from custom_components.ufh_controller.const import (
+    DEFAULT_CYCLE_MODE_HOURS,
+    DEFAULT_PID,
+    DEFAULT_SETPOINT,
+)
+
 from .pid import PIDController
 from .zone import (
     CircuitType,
@@ -22,9 +28,6 @@ from .zone import (
     evaluate_zone,
 )
 
-# Cycle mode duration in hours per zone (including rest hour)
-_CYCLE_MODE_HOURS = 8
-
 
 @dataclass
 class ZoneConfig:
@@ -36,14 +39,14 @@ class ZoneConfig:
     valve_switch: str
     circuit_type: CircuitType = CircuitType.REGULAR
     window_sensors: list[str] = field(default_factory=list)
-    setpoint_min: float = 16.0
-    setpoint_max: float = 28.0
-    setpoint_default: float = 21.0
-    kp: float = 50.0
-    ki: float = 0.05
-    kd: float = 0.0
-    integral_min: float = 0.0
-    integral_max: float = 100.0
+    setpoint_min: float = DEFAULT_SETPOINT["min"]
+    setpoint_max: float = DEFAULT_SETPOINT["max"]
+    setpoint_default: float = DEFAULT_SETPOINT["default"]
+    kp: float = DEFAULT_PID["kp"]
+    ki: float = DEFAULT_PID["ki"]
+    kd: float = DEFAULT_PID["kd"]
+    integral_min: float = DEFAULT_PID["integral_min"]
+    integral_max: float = DEFAULT_PID["integral_max"]
 
 
 @dataclass
@@ -319,7 +322,7 @@ class HeatingController:
         """Evaluate zone action for cycle mode."""
         # Get current hour of day
         now = datetime.now(UTC)
-        cycle_hour = now.hour % _CYCLE_MODE_HOURS
+        cycle_hour = now.hour % DEFAULT_CYCLE_MODE_HOURS
         valve_on = runtime.state.valve_on
 
         if cycle_hour == 0:

--- a/custom_components/ufh_controller/core/history.py
+++ b/custom_components/ufh_controller/core/history.py
@@ -10,14 +10,18 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
+from custom_components.ufh_controller.const import (
+    DEFAULT_TIMING,
+    DEFAULT_WINDOW_CENTER_MINUTE,
+)
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
-# Threshold for centering the duty cycle window
-_WINDOW_CENTER_MINUTE = 30
 
-
-def get_observation_start(now: datetime, observation_period: int = 7200) -> datetime:
+def get_observation_start(
+    now: datetime, observation_period: int = DEFAULT_TIMING["observation_period"]
+) -> datetime:
     """
     Get the start time of the current observation period.
 
@@ -42,7 +46,7 @@ def get_observation_start(now: datetime, observation_period: int = 7200) -> date
 
 
 def get_duty_cycle_window(
-    now: datetime, window_seconds: int = 3600
+    now: datetime, window_seconds: int = DEFAULT_TIMING["duty_cycle_window"]
 ) -> tuple[datetime, datetime]:
     """
     Get the time window for duty cycle calculation.
@@ -60,7 +64,7 @@ def get_duty_cycle_window(
     """
     window = timedelta(seconds=window_seconds)
 
-    if now.minute < _WINDOW_CENTER_MINUTE:
+    if now.minute < DEFAULT_WINDOW_CENTER_MINUTE:
         start = now - window
         end = now
     else:
@@ -72,7 +76,7 @@ def get_duty_cycle_window(
 
 
 def get_valve_open_window(
-    now: datetime, valve_open_time: int = 210
+    now: datetime, valve_open_time: int = DEFAULT_TIMING["valve_open_time"]
 ) -> tuple[datetime, datetime]:
     """
     Get the time window for valve open detection.

--- a/custom_components/ufh_controller/core/zone.py
+++ b/custom_components/ufh_controller/core/zone.py
@@ -11,8 +11,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 
-# Threshold for considering valve fully open (85%)
-_VALVE_OPEN_THRESHOLD = 0.85
+from custom_components.ufh_controller.const import (
+    DEFAULT_SETPOINT,
+    DEFAULT_TIMING,
+    DEFAULT_VALVE_OPEN_THRESHOLD,
+)
 
 
 class CircuitType(StrEnum):
@@ -39,13 +42,13 @@ class TimingParams:
     All durations are in seconds.
     """
 
-    observation_period: int = 7200
-    duty_cycle_window: int = 3600
-    min_run_time: int = 540
-    valve_open_time: int = 210
-    closing_warning_duration: int = 240
-    window_block_threshold: float = 0.05
-    controller_loop_interval: int = 60
+    observation_period: int = DEFAULT_TIMING["observation_period"]
+    duty_cycle_window: int = DEFAULT_TIMING["duty_cycle_window"]
+    min_run_time: int = DEFAULT_TIMING["min_run_time"]
+    valve_open_time: int = DEFAULT_TIMING["valve_open_time"]
+    closing_warning_duration: int = DEFAULT_TIMING["closing_warning_duration"]
+    window_block_threshold: float = DEFAULT_TIMING["window_block_threshold"]
+    controller_loop_interval: int = DEFAULT_TIMING["controller_loop_interval"]
 
 
 @dataclass
@@ -62,7 +65,7 @@ class ZoneState:
 
     # PID state
     current: float | None = None
-    setpoint: float = 21.0
+    setpoint: float = DEFAULT_SETPOINT["default"]
     error: float = 0.0
     p_term: float = 0.0
     i_term: float = 0.0
@@ -215,7 +218,7 @@ def should_request_heat(
         return False
 
     # Wait for valve to fully open
-    if zone.open_state_avg < _VALVE_OPEN_THRESHOLD:
+    if zone.open_state_avg < DEFAULT_VALVE_OPEN_THRESHOLD:
         return False
 
     # Don't request if zone is about to close

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,6 +20,7 @@ from custom_components.ufh_controller.const import (
     DOMAIN,
     SUBENTRY_TYPE_CONTROLLER,
     SUBENTRY_TYPE_ZONE,
+    TimingDefaults,
 )
 
 # =============================================================================
@@ -487,13 +488,14 @@ def test_get_timing_schema_with_defaults() -> None:
 
 def test_get_timing_schema_with_custom() -> None:
     """Test that timing schema uses provided timing values."""
-    custom_timing = {
+    custom_timing: TimingDefaults = {
         "observation_period": 9000,
         "duty_cycle_window": 4500,
         "min_run_time": 600,
         "valve_open_time": 300,
         "closing_warning_duration": 300,
         "window_block_threshold": 0.15,
+        "controller_loop_interval": 60,
     }
     schema = get_timing_schema(custom_timing)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -5,6 +5,10 @@ from unittest.mock import patch
 
 import pytest
 
+from custom_components.ufh_controller.const import (
+    DEFAULT_PID,
+    DEFAULT_SETPOINT,
+)
 from custom_components.ufh_controller.core.controller import (
     ControllerConfig,
     HeatingController,
@@ -556,11 +560,11 @@ class TestZoneConfig:
             valve_switch="switch.test_valve",
         )
         assert config.circuit_type == CircuitType.REGULAR
-        assert config.setpoint_min == 16.0
-        assert config.setpoint_max == 28.0
-        assert config.setpoint_default == 21.0
-        assert config.kp == 50.0
-        assert config.ki == 0.05
+        assert config.setpoint_min == DEFAULT_SETPOINT["min"]
+        assert config.setpoint_max == DEFAULT_SETPOINT["max"]
+        assert config.setpoint_default == DEFAULT_SETPOINT["default"]
+        assert config.kp == DEFAULT_PID["kp"]
+        assert config.ki == DEFAULT_PID["ki"]
 
     def test_flush_circuit(self) -> None:
         """Test flush circuit configuration."""


### PR DESCRIPTION
This commit consolidates all magic numerical constants that were sprinkled across the codebase into a single source of truth in const.py.

Key changes:
- Add TypedDict definitions for DEFAULT_TIMING, DEFAULT_PID, DEFAULT_SETPOINT to enable proper type checking across the codebase
- Add new constants: DEFAULT_CYCLE_MODE_HOURS, DEFAULT_VALVE_OPEN_THRESHOLD, DEFAULT_WINDOW_CENTER_MINUTE
- Add UI validation constraint constants for config_flow.py
- Fix critical ki inconsistency: ZoneConfig defaulted to 0.05 but DEFAULT_PID specified 0.001 (50x difference!)
- Update ZoneConfig, TimingParams, ZoneState to use constants from const.py
- Update coordinator.py fallback values to use constants
- Update config_flow.py UI validation to use constants
- Update history.py function defaults to use constants
- Update tests to use constants instead of magic numbers