### PR TITLE
Fix update_zone_historical method parameters

### DIFF
--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -231,8 +231,7 @@ class HeatingController:
         period_state_avg: float,
         open_state_avg: float,
         window_open_avg: float,
-        elapsed_time: float | None = None,
-        observation_period: int | None = None,
+        elapsed_time: float,
     ) -> None:
         """
         Update zone historical averages from Recorder queries.
@@ -244,8 +243,6 @@ class HeatingController:
             open_state_avg: Average valve state for open detection.
             window_open_avg: Average window open state.
             elapsed_time: Actual elapsed time since observation start in seconds.
-                If None, defaults to observation_period (full period).
-            observation_period: Optional override for period duration.
 
         """
         runtime = self._zones.get(zone_id)
@@ -258,10 +255,8 @@ class HeatingController:
         runtime.state.window_open_avg = window_open_avg
 
         # Calculate used and requested durations
-        period = observation_period or self.config.timing.observation_period
-        # used_duration is based on actual elapsed time, not full period
-        actual_elapsed = elapsed_time if elapsed_time is not None else period
-        runtime.state.used_duration = period_state_avg * actual_elapsed
+        period = self.config.timing.observation_period
+        runtime.state.used_duration = period_state_avg * elapsed_time
         # requested_duration uses full observation period
         runtime.state.requested_duration = calculate_requested_duration(
             runtime.state.duty_cycle,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -235,6 +235,7 @@ class TestUpdateZoneHistorical:
             period_state_avg=0.25,
             open_state_avg=0.9,
             window_open_avg=0.0,
+            elapsed_time=7200.0,  # Full observation period
         )
 
         state = controller.get_zone_state("living_room")
@@ -256,6 +257,7 @@ class TestUpdateZoneHistorical:
             period_state_avg=0.25,
             open_state_avg=0.9,
             window_open_avg=0.0,
+            elapsed_time=7200.0,
         )
 
     def test_used_duration_with_elapsed_time(
@@ -341,6 +343,7 @@ class TestEvaluateZonesAutoMode:
             period_state_avg=0.0,  # No usage yet
             open_state_avg=0.0,
             window_open_avg=0.0,
+            elapsed_time=7200.0,  # Full observation period
         )
 
         actions = controller.evaluate_zones()
@@ -525,6 +528,7 @@ class TestCalculateHeatRequest:
             period_state_avg=0.0,
             open_state_avg=0.9,  # Above 0.85 threshold
             window_open_avg=0.0,
+            elapsed_time=7200.0,  # Full observation period
         )
         # Manually set valve on
         runtime = controller.get_zone_runtime("living_room")


### PR DESCRIPTION
The update_zone_historical method now requires elapsed_time to be provided explicitly, rather than defaulting to observation_period. The observation_period parameter has been removed since it should always come from the controller config.