### PR TITLE
Disable HACS validation in CI temporarily

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,16 +25,17 @@ jobs:
       - name: Run hassfest validation
         uses: home-assistant/actions/hassfest@master
 
-  hacs: # https://github.com/hacs/action
-    name: HACS validation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v6
+  # TODO: Re-enable HACS validation when repository is public
+  # hacs: # https://github.com/hacs/action
+  #   name: HACS validation
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout the repository
+  #       uses: actions/checkout@v6
 
-      - name: Run HACS validation
-        uses: hacs/action@main
-        with:
-          category: integration
-          # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
-          ignore: brands
+  #     - name: Run HACS validation
+  #       uses: hacs/action@main
+  #       with:
+  #         category: integration
+  #         # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
+  #         ignore: brands


### PR DESCRIPTION
HACS validation requires the repository to be public. Commented out the job with a TODO marker for easy re-enabling once published.