### PR TITLE
Add comprehensive configuration reference to specification

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -18,6 +18,7 @@ This document specifies a custom Home Assistant integration for multi-zone hydro
 10. [Testing Strategy](#10-testing-strategy)
 11. [CI/CD Pipeline](#11-cicd-pipeline)
 12. [Risks & Mitigations](#12-risks--mitigations)
+13. [Configuration Reference](#13-configuration-reference)
 
 ---
 
@@ -975,6 +976,396 @@ repos:
 
 ---
 
+## 13. Configuration Reference
+
+This section provides detailed documentation for all configuration parameters in the UFH Controller. Each parameter directly affects how the heating system operates.
+
+### 13.1 Timing Parameters
+
+Timing parameters control the scheduling, valve operation, and observation windows used by the controller. All values are in seconds unless otherwise noted.
+
+#### observation_period
+
+**Default:** 7200 seconds (2 hours)
+**Range:** 1800-14400 seconds (30 minutes to 4 hours)
+**Config location:** Controller subentry → `data.timing.observation_period`
+
+The observation period defines the time window used for quota-based valve scheduling. Each zone is allocated a "quota" of valve-on time based on its PID-calculated duty cycle, and this quota is distributed across the observation period.
+
+**How it works:** Observation periods are aligned to even hours (00:00, 02:00, 04:00, etc.). When an observation period ends, a new one begins and all zone quotas reset. The controller calculates how much time each zone's valve has been open during the current period (`used_duration`) and compares it to how much time it should be open (`requested_duration = duty_cycle% × observation_period`).
+
+**Examples:**
+- With a 2-hour (7200s) observation period and a zone duty cycle of 50%, the zone's valve should be open for 3600 seconds (1 hour) during that period.
+- If a zone has been on for 2000 seconds already and needs 3600 total, it still has 1600 seconds of quota remaining and will be allowed to turn on again.
+
+**Why it matters:** Shorter periods allow more responsive heating but may cause more valve cycling. Longer periods reduce valve wear but make the system less responsive to temperature changes.
+
+#### min_run_time
+
+**Default:** 540 seconds (9 minutes)
+**Range:** 60-1800 seconds (1 to 30 minutes)
+**Config location:** Controller subentry → `data.timing.min_run_time`
+
+The minimum duration a valve must run if turned on. This prevents rapid valve cycling which causes mechanical wear and inefficient heating.
+
+**How it works:** Before turning on a valve, the controller checks if the zone's remaining quota is at least `min_run_time`. If a zone only has 300 seconds of quota remaining but `min_run_time` is 540 seconds, the valve stays off rather than doing a short run.
+
+**Examples:**
+- Zone has used 6700s of a 7200s quota (500s remaining). With `min_run_time=540s`, the valve won't turn on because 500 < 540.
+- Zone has used 0s of a 3600s quota (3600s remaining). With `min_run_time=540s`, the valve can turn on because 3600 > 540.
+
+**Why it matters:** Too low causes valve wear from frequent switching. Too high prevents zones from using their full quota in small increments, potentially reducing heating effectiveness.
+
+#### valve_open_time
+
+**Default:** 210 seconds (3.5 minutes)
+**Range:** 60-600 seconds (1 to 10 minutes)
+**Config location:** Controller subentry → `data.timing.valve_open_time`
+
+The time window used to detect when a valve is fully open before requesting heat from the boiler.
+
+**How it works:** The controller queries the valve's historical state over the last `valve_open_time` seconds. If the valve has been on for at least 85% of that window (`open_state_avg ≥ 0.85`), it's considered fully open and can contribute to the heat request. This prevents firing the boiler before water can flow through the zone.
+
+**Examples:**
+- Valve turned on 4 minutes ago. With `valve_open_time=210s`, the controller checks the last 210 seconds and finds the valve was on for 100% of that time. The zone requests heat.
+- Valve just turned on 30 seconds ago. With `valve_open_time=210s`, the controller only sees 30 seconds of on-time, which is < 85% of 210 seconds. The zone doesn't request heat yet.
+
+**Why it matters:** Too short risks firing the boiler before valves are open, wasting energy. Too long delays heat delivery and reduces comfort.
+
+#### closing_warning_duration
+
+**Default:** 240 seconds (4 minutes)
+**Range:** 60-600 seconds (1 to 10 minutes)
+**Config location:** Controller subentry → `data.timing.closing_warning_duration`
+
+The minimum quota remaining before a zone stops requesting heat from the boiler, even if the valve is still open.
+
+**How it works:** When a zone has less than `closing_warning_duration` seconds of quota remaining, it stops contributing to the heat request signal. This gives the boiler advance notice that the zone is about to close, preventing short heating cycles.
+
+**Examples:**
+- Zone has 1000s quota, used 800s, leaving 200s remaining. With `closing_warning_duration=240s`, the zone stops requesting heat because 200 < 240, even though the valve stays open.
+- Zone has 3600s quota, used 3000s, leaving 600s remaining. With `closing_warning_duration=240s`, the zone continues requesting heat because 600 > 240.
+
+**Why it matters:** Prevents the boiler from firing up shortly before a valve closes, which wastes energy and causes inefficient cycling.
+
+#### window_block_time
+
+**Default:** 600 seconds (10 minutes)
+**Range:** 0-3600 seconds (0 to 60 minutes)
+**Config location:** Controller subentry → `data.timing.window_block_time`
+
+The maximum accumulated time windows/doors can be open during the current observation period before heating is blocked for that zone.
+
+**How it works:** The controller tracks how many total seconds any window sensor was open during the current observation period (`window_open_seconds`). If this exceeds `window_block_time`, the zone's valve is turned off and PID integration is paused. Additionally, if any window is currently open right now (`window_currently_open=True`), the valve is immediately turned off regardless of accumulated time.
+
+**Examples:**
+- A window was open for 3 minutes (180s), then closed, then opened again for 5 minutes (300s). Total `window_open_seconds = 480s`. With `window_block_time=600s`, heating continues.
+- Same scenario but window opened a third time for 3 minutes (180s). Now `window_open_seconds = 660s`. With `window_block_time=600s`, heating is blocked for this zone.
+- Window is currently open right now → valve immediately turns off, regardless of `window_block_time`.
+
+**Why it matters:** Prevents wasting energy heating a room while a window is open. Setting to 0 disables time-based blocking but immediate blocking (window currently open) still applies.
+
+#### controller_loop_interval
+
+**Default:** 60 seconds
+**Range:** 10-300 seconds
+**Config location:** Controller subentry → `data.timing.controller_loop_interval`
+
+The interval at which the coordinator runs the control loop, updating PID controllers and making valve decisions.
+
+**How it works:** Every `controller_loop_interval` seconds, the coordinator:
+1. Updates each zone's PID controller with the latest temperature
+2. Queries historical state from the recorder
+3. Evaluates zone decisions
+4. Aggregates heat request
+5. Updates all entities
+
+**Examples:**
+- With `controller_loop_interval=60s`, the PID controller receives updates every minute, and `dt=60` in the PID calculations.
+- With `controller_loop_interval=30s`, updates happen twice as often with `dt=30`.
+
+**Why it matters:** Shorter intervals provide more responsive control but increase database load from recorder queries. Longer intervals reduce load but make the system less responsive. 60 seconds is a good balance for residential heating.
+
+---
+
+### 13.2 PID Parameters
+
+PID parameters control the temperature regulation algorithm for each zone. These are configured per-zone and affect how aggressively the system responds to temperature errors.
+
+#### kp (Proportional Gain)
+
+**Default:** 50.0
+**Range:** Any positive float (typically 1.0-200.0)
+**Config location:** Zone subentry → `data.pid.kp`
+
+The proportional gain determines the immediate response to temperature error. Higher values create stronger responses to temperature deviations.
+
+**How it works:** The proportional term is calculated as `p_term = kp × error`, where `error = setpoint - current_temperature`. If the room is 2°C below setpoint and `kp=50`, then `p_term = 50 × 2 = 100%` duty cycle (clamped to 100%).
+
+**Examples:**
+- Room at 20°C, setpoint 21°C, `kp=50`: `p_term = 50 × 1 = 50%` duty cycle.
+- Room at 19°C, setpoint 21°C, `kp=50`: `p_term = 50 × 2 = 100%` duty cycle.
+- Room at 20.5°C, setpoint 21°C, `kp=50`: `p_term = 50 × 0.5 = 25%` duty cycle.
+- Same conditions with `kp=100`: `p_term = 100 × 0.5 = 50%` duty cycle (more aggressive).
+
+**Why it matters:** Too low results in slow temperature recovery. Too high causes oscillation around the setpoint. For hydronic heating with slow thermal response, 50.0 is a good starting point.
+
+#### ki (Integral Gain)
+
+**Default:** 0.001
+**Range:** Any positive float (typically 0.0001-0.01)
+**Config location:** Zone subentry → `data.pid.ki`
+
+The integral gain determines how past temperature errors accumulate to eliminate steady-state error. The integral term grows over time when temperature remains below setpoint.
+
+**How it works:** The integral accumulates as `integral += ki × error × dt` (in % units). With `ki=0.001`, `error=1°C`, and `dt=60s`, the integral increases by `0.001 × 1 × 60 = 0.06%` per control cycle. Over time, this adds up to eliminate persistent errors.
+
+**Examples:**
+- Room stuck at 20.5°C, setpoint 21°C (error = 0.5°C), `ki=0.001`, `dt=60s`:
+  - After 1 minute: `integral += 0.001 × 0.5 × 60 = 0.03%`
+  - After 10 minutes: `integral ≈ 0.3%` (accumulated)
+  - After 1 hour: `integral ≈ 1.8%` (accumulated)
+- With higher `ki=0.01`, the same scenario accumulates 10× faster, reaching 18% after 1 hour.
+
+**Why it matters:** The integral term ensures the room eventually reaches the exact setpoint even if the proportional term alone isn't enough. Too low and the room never quite reaches setpoint. Too high causes overshoot and oscillation. The default `0.001` provides gentle long-term correction.
+
+**Special note:** The integral is stored in percentage units (not raw error-seconds), so changing `ki` doesn't immediately affect the accumulated contribution—only future accumulation rates change.
+
+#### kd (Derivative Gain)
+
+**Default:** 0.0
+**Range:** Any positive float (typically 0.0-10.0)
+**Config location:** Zone subentry → `data.pid.kd`
+
+The derivative gain responds to the rate of change of temperature error, providing damping against oscillations.
+
+**How it works:** The derivative term is calculated as `d_term = kd × (error - last_error) / dt`. If temperature is changing rapidly, the derivative term adjusts the output to slow the approach to setpoint.
+
+**Examples:**
+- Error changed from 1.0°C to 0.5°C in 60 seconds, `kd=10`:
+  - `d_term = 10 × (0.5 - 1.0) / 60 = -0.083%` (negative because error is decreasing)
+- Error changed from 0.5°C to 2.0°C in 60 seconds, `kd=10`:
+  - `d_term = 10 × (2.0 - 0.5) / 60 = 0.25%` (positive because error is increasing)
+
+**Why it matters:** Derivative control can reduce overshoot and oscillation in fast-responding systems. However, hydronic heating systems are very slow and derivative control often adds noise rather than improvement. The default `kd=0.0` disables derivative control, which is appropriate for most UFH systems.
+
+#### integral_min
+
+**Default:** 0.0
+**Range:** Any float (typically -100.0 to 0.0)
+**Config location:** Zone subentry → `data.pid.integral_min`
+
+The minimum allowed value for the integral term in percentage units. This prevents integral windup in the negative direction.
+
+**How it works:** After each PID update, the integral is clamped: `integral = max(integral_min, min(integral_max, integral))`. Since heating systems can only add heat (not cool), negative integral values are typically not useful.
+
+**Examples:**
+- Room at 22°C, setpoint 21°C (error = -1°C). With `integral_min=0.0`, the integral cannot go below 0%, preventing negative accumulation.
+- With `integral_min=-50.0`, the integral could accumulate to -50% before clamping, allowing future overcooling to be "remembered."
+
+**Why it matters:** For heating-only systems, `integral_min=0.0` is correct since we can't cool the room. For systems with both heating and cooling, you might use negative values.
+
+#### integral_max
+
+**Default:** 100.0
+**Range:** Any positive float (typically 50.0-200.0)
+**Config location:** Zone subentry → `data.pid.integral_max`
+
+The maximum allowed value for the integral term in percentage units. This prevents integral windup when heating is blocked or ineffective.
+
+**How it works:** The integral is clamped to this maximum, preventing unbounded accumulation when the room can't reach setpoint (e.g., when it's very cold outside or heating capacity is insufficient).
+
+**Examples:**
+- Room stuck at 19°C, setpoint 21°C. Integral keeps accumulating but stops at `integral_max=100%`.
+- When the room finally warms up, the integral doesn't cause massive overshoot because it was limited to 100%.
+
+**Why it matters:** Prevents "integral windup" where prolonged errors cause the integral term to grow excessively, leading to overshoot when conditions change. 100% is a safe limit for most systems.
+
+---
+
+### 13.3 Setpoint Parameters
+
+Setpoint parameters define the allowed temperature range and precision for each zone's target temperature.
+
+#### setpoint_min
+
+**Default:** 16.0°C
+**Range:** 5.0-30.0°C
+**Config location:** Zone subentry → `data.setpoint.min`
+
+The minimum allowed setpoint temperature for the zone climate entity.
+
+**How it works:** Users cannot set the target temperature below this value in the Home Assistant UI. The controller also clamps any setpoint changes to this minimum.
+
+**Examples:**
+- With `setpoint_min=16.0`, the climate entity's temperature slider starts at 16°C.
+- User tries to set 14°C via an automation → controller clamps to 16°C.
+
+**Why it matters:** Prevents accidentally setting temperatures too low, which could risk pipe freezing or excessive energy waste when recovering.
+
+#### setpoint_max
+
+**Default:** 28.0°C
+**Range:** 5.0-35.0°C
+**Config location:** Zone subentry → `data.setpoint.max`
+
+The maximum allowed setpoint temperature for the zone climate entity.
+
+**How it works:** Users cannot set the target temperature above this value. The controller clamps any setpoint changes to this maximum.
+
+**Examples:**
+- With `setpoint_max=28.0`, the climate entity's temperature slider ends at 28°C.
+- User tries to set 30°C via an automation → controller clamps to 28°C.
+
+**Why it matters:** Prevents overheating rooms and excessive energy use. Also protects against misconfiguration or automation errors.
+
+#### setpoint_step
+
+**Default:** 0.5°C
+**Range:** 0.1-1.0°C (from UI constraints)
+**Config location:** Zone subentry → `data.setpoint.step`
+
+The increment size for setpoint adjustments in the Home Assistant UI.
+
+**How it works:** Defines the granularity of the temperature slider and up/down buttons in the climate entity UI.
+
+**Examples:**
+- With `step=0.5`, the slider allows 16.0°C, 16.5°C, 17.0°C, etc.
+- With `step=0.1`, the slider allows finer control: 16.0°C, 16.1°C, 16.2°C, etc.
+
+**Why it matters:** Finer steps (0.1°C) allow more precise control but may be unnecessarily granular for slow-responding hydronic systems. 0.5°C is a practical compromise.
+
+#### setpoint_default
+
+**Default:** 21.0°C
+**Range:** 5.0-35.0°C
+**Config location:** Zone subentry → `data.setpoint.default`
+
+The initial target temperature when the zone is first created or reset.
+
+**How it works:** This is the setpoint value used when the climate entity is first set up. It should fall between `setpoint_min` and `setpoint_max`.
+
+**Examples:**
+- New zone created with `setpoint_default=21.0` → climate entity starts at 21°C.
+- Zone typically uses preset modes → `setpoint_default` is only used until first preset is selected.
+
+**Why it matters:** Sets a sensible starting point for new zones. Usually matches the "home" or "comfort" preset temperature.
+
+---
+
+### 13.4 Preset Temperatures
+
+Preset temperatures provide quick access to common temperature settings. Users can switch between presets in the climate entity UI instead of manually adjusting the setpoint.
+
+#### home
+
+**Default:** 21.0°C
+**Config location:** Zone subentry → `data.presets.home`
+
+Standard comfort temperature when occupants are home and active.
+
+**Example:** User arrives home, switches climate entity to "Home" preset → setpoint changes to 21°C.
+
+#### away
+
+**Default:** 16.0°C
+**Config location:** Zone subentry → `data.presets.away`
+
+Energy-saving temperature when the home is unoccupied for extended periods (vacation, work trips).
+
+**Example:** User leaves for a week, switches to "Away" preset → setpoint drops to 16°C, saving energy while preventing pipe freezing.
+
+#### eco
+
+**Default:** 19.0°C
+**Config location:** Zone subentry → `data.presets.eco`
+
+Moderate energy-saving temperature for daily use when comfort can be slightly reduced.
+
+**Example:** Overnight or during the workday, switch to "Eco" preset → setpoint at 19°C reduces energy use while maintaining basic comfort.
+
+#### comfort
+
+**Default:** 22.0°C
+**Config location:** Zone subentry → `data.presets.comfort`
+
+Higher comfort temperature for maximum coziness.
+
+**Example:** Cold winter evening, switch to "Comfort" preset → setpoint increases to 22°C for extra warmth.
+
+#### boost
+
+**Default:** 25.0°C
+**Config location:** Zone subentry → `data.presets.boost`
+
+Maximum temperature for rapid heating or special situations.
+
+**Example:** Bathroom zone before a shower, switch to "Boost" preset → setpoint jumps to 25°C for quick warmth, then returns to normal.
+
+**Note:** All presets are optional. If not configured during zone setup, preset support is disabled and users control temperature via the setpoint slider only.
+
+---
+
+### 13.5 Controller-Level Configuration
+
+These parameters are configured once for the entire controller during initial setup.
+
+#### heat_request_entity
+
+**Type:** Switch entity
+**Required:** No
+**Config location:** ConfigEntry → `data.heat_request_entity`
+
+A switch entity that signals the boiler to provide heat. When zones request heat, this switch is turned on. When no zones need heat, it's turned off.
+
+**How it works:** The controller aggregates heat requests from all zones and sets this switch accordingly. Typically connected to a relay or smart switch controlling the boiler's heat request input.
+
+**Example:** `switch.boiler_heat_request` → When any zone valve is fully open and requesting heat, this switch turns on, telling the boiler to fire.
+
+**Why it matters:** Allows the controller to manage boiler firing. If not configured, the boiler must remain in a mode where it's always ready to provide heat.
+
+#### dhw_active_entity
+
+**Type:** Binary sensor entity
+**Required:** No
+**Config location:** ConfigEntry → `data.dhw_active_entity`
+
+A binary sensor indicating when the boiler is heating domestic hot water (DHW).
+
+**How it works:** When this sensor is "on," regular heating circuits wait (DHW priority) and flush circuits can capture latent heat if enabled.
+
+**Example:** `binary_sensor.boiler_tapwater_active` → When someone takes a shower, this turns on, and regular zones pause to give DHW priority.
+
+**Why it matters:** Prevents the heating system from competing with DHW heating, which typically has priority. Also enables flush circuits to capture waste heat.
+
+#### circulation_entity
+
+**Type:** Binary sensor entity
+**Required:** No
+**Config location:** ConfigEntry → `data.circulation_entity`
+
+A binary sensor indicating when the boiler's circulation pump is running.
+
+**How it works:** Currently informational; may be used in future features for detecting flow/no-flow conditions.
+
+**Example:** `binary_sensor.boiler_circulation` → Indicates water is circulating through the heating system.
+
+#### summer_mode_entity
+
+**Type:** Select entity
+**Required:** No
+**Config location:** ConfigEntry → `data.summer_mode_entity`
+
+A select entity on the boiler to toggle between "summer" (heating circuit disabled, DHW only) and "winter" (heating circuit enabled) modes.
+
+**How it works:** The controller automatically sets this to "winter" when heat is needed and "summer" when no heat is needed, saving energy by disabling the heating circuit when not in use.
+
+**Example:** `select.boiler_summer_mode` → Set to "winter" when zones request heat, "summer" when idle.
+
+**Why it matters:** Reduces standby energy consumption by disabling the heating circuit when not needed. Alternative to using `heat_request_entity`.
+
+---
+
 ## Appendix A: Default Values
 
 ```python
@@ -988,7 +1379,7 @@ DEFAULT_TIMING = {
 
 DEFAULT_PID = {
     "kp": 50.0,
-    "ki": 0.05,
+    "ki": 0.001,
     "kd": 0.0,
     "integral_min": 0.0,
     "integral_max": 100.0,


### PR DESCRIPTION
Added Section 13: Configuration Reference with detailed documentation
for all configuration parameters:

- Timing parameters (observation_period, min_run_time, valve_open_time,
  closing_warning_duration, window_block_time, controller_loop_interval)
- PID parameters (kp, ki, kd, integral_min, integral_max)
- Setpoint parameters (min, max, step, default)
- Preset temperatures (home, away, eco, comfort, boost)
- Controller-level configuration (heat_request_entity, dhw_active_entity,
  circulation_entity, summer_mode_entity)

Each parameter includes:
- Default value and allowed range
- Config location (where it's stored)
- Detailed explanation of how it works
- 1-2 concrete examples
- Why it matters (impact on system behavior)

Also fixed ki default value in Appendix A (was 0.05, corrected to 0.001
to match implementation in const.py).

This addresses confusion about parameter behavior by providing clear,
detailed documentation cross-referenced with the implementation and tests.