### PR TITLE
Extract summer mode constants and fix fallback

### DIFF
--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -31,6 +31,21 @@ class OperationMode(StrEnum):
     DISABLED = "disabled"
 
 
+class SummerMode(StrEnum):
+    """
+    Boiler summer mode values.
+
+    Controls whether the boiler's heating circuit is active:
+    - AUTO: Boiler controls summer/winter mode automatically
+    - WINTER: Heating circuit enabled (for UFH heating)
+    - SUMMER: Heating circuit disabled (DHW only)
+    """
+
+    AUTO = "auto"
+    WINTER = "winter"
+    SUMMER = "summer"
+
+
 class ControllerStatus(StrEnum):
     """Controller operational status for error tracking."""
 

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -22,6 +22,7 @@ from .const import (
     SUBENTRY_TYPE_ZONE,
     ControllerStatus,
     OperationMode,
+    SummerMode,
 )
 from .core import (
     ControllerConfig,
@@ -394,13 +395,13 @@ class UFHControllerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Turn off heat request
         await self._execute_heat_request(heat_request=False)
 
-        # Set summer mode to 'summer' (disable heating circuit)
+        # Set summer mode to 'auto' to pass control back to the boiler
         summer_entity = self._controller.config.summer_mode_entity
         if summer_entity:
             await self.hass.services.async_call(
                 "select",
                 "select_option",
-                {"entity_id": summer_entity, "option": "summer"},
+                {"entity_id": summer_entity, "option": SummerMode.AUTO},
             )
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -14,6 +14,7 @@ from custom_components.ufh_controller.const import (
     DEFAULT_CYCLE_MODE_HOURS,
     DEFAULT_PID,
     DEFAULT_SETPOINT,
+    SummerMode,
 )
 
 from .pid import PIDController
@@ -419,7 +420,8 @@ class HeatingController:
             heat_request: Current heat request state.
 
         Returns:
-            "winter" for heating, "summer" for no heating, or None if not applicable.
+            SummerMode.WINTER for heating, SummerMode.SUMMER for no heating,
+            or None if not applicable.
 
         """
         if self.config.summer_mode_entity is None:
@@ -431,13 +433,13 @@ class HeatingController:
             return None
 
         if mode in ("flush", "all_off"):
-            return "summer"
+            return SummerMode.SUMMER
 
         if mode == "all_on":
-            return "winter"
+            return SummerMode.WINTER
 
         # Auto and cycle modes depend on heat request
-        return "winter" if heat_request else "summer"
+        return SummerMode.WINTER if heat_request else SummerMode.SUMMER
 
     @property
     def zone_ids(self) -> list[str]:

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -733,7 +733,7 @@ The coordinator tracks consecutive failures and implements escalating responses:
 When fail-safe mode activates:
 1. All valves are commanded closed
 2. Heat request is turned off
-3. Summer mode (if configured) is set to "summer"
+3. Summer mode (if configured) is set to "auto" (passes control back to the boiler)
 4. Persistent notification is created
 
 **Controller Status Entity:**

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -8,6 +8,7 @@ import pytest
 from custom_components.ufh_controller.const import (
     DEFAULT_PID,
     DEFAULT_SETPOINT,
+    SummerMode,
 )
 from custom_components.ufh_controller.core.controller import (
     ControllerConfig,
@@ -852,7 +853,7 @@ class TestGetSummerModeValue:
         )
         controller = HeatingController(config)
         controller.mode = "flush"
-        assert controller.get_summer_mode_value(heat_request=True) == "summer"
+        assert controller.get_summer_mode_value(heat_request=True) == SummerMode.SUMMER
 
     def test_all_off_mode_returns_summer(self) -> None:
         """Test all_off mode returns summer."""
@@ -864,7 +865,7 @@ class TestGetSummerModeValue:
         )
         controller = HeatingController(config)
         controller.mode = "all_off"
-        assert controller.get_summer_mode_value(heat_request=False) == "summer"
+        assert controller.get_summer_mode_value(heat_request=False) == SummerMode.SUMMER
 
     def test_all_on_mode_returns_winter(self) -> None:
         """Test all_on mode returns winter."""
@@ -876,7 +877,7 @@ class TestGetSummerModeValue:
         )
         controller = HeatingController(config)
         controller.mode = "all_on"
-        assert controller.get_summer_mode_value(heat_request=True) == "winter"
+        assert controller.get_summer_mode_value(heat_request=True) == SummerMode.WINTER
 
     def test_auto_mode_with_heat_request(self) -> None:
         """Test auto mode with heat request returns winter."""
@@ -887,7 +888,7 @@ class TestGetSummerModeValue:
             zones=[],
         )
         controller = HeatingController(config)
-        assert controller.get_summer_mode_value(heat_request=True) == "winter"
+        assert controller.get_summer_mode_value(heat_request=True) == SummerMode.WINTER
 
     def test_auto_mode_without_heat_request(self) -> None:
         """Test auto mode without heat request returns summer."""
@@ -898,7 +899,7 @@ class TestGetSummerModeValue:
             zones=[],
         )
         controller = HeatingController(config)
-        assert controller.get_summer_mode_value(heat_request=False) == "summer"
+        assert controller.get_summer_mode_value(heat_request=False) == SummerMode.SUMMER
 
 
 class TestZoneConfig:

--- a/tests/test_entity_unavailability.py
+++ b/tests/test_entity_unavailability.py
@@ -13,6 +13,7 @@ from custom_components.ufh_controller.const import (
     DEFAULT_TIMING,
     DOMAIN,
     SUBENTRY_TYPE_ZONE,
+    SummerMode,
 )
 
 MOCK_CONTROLLER_ID = "test_controller"
@@ -318,12 +319,12 @@ async def test_summer_mode_value_calculation(
     await hass.async_block_till_done()
 
     coordinator = mock_config_entry_with_summer_mode.runtime_data.coordinator
-    # No heat request should mean "summer" mode
+    # No heat request should mean SummerMode.SUMMER
     heat_request = coordinator.controller.calculate_heat_request()
     summer_mode_value = coordinator.controller.get_summer_mode_value(
         heat_request=heat_request
     )
-    assert summer_mode_value == "summer"
+    assert summer_mode_value == SummerMode.SUMMER
 
 
 # ============================================================================


### PR DESCRIPTION
- Add SummerMode enum with AUTO, WINTER, SUMMER values to const.py
- Replace all "summer"/"winter" string literals with SummerMode constants
- Fix fail-safe mode to set summer mode to AUTO instead of SUMMER (passes control back to the boiler rather than disabling heating)
- Update specification to document the corrected fail-safe behavior