### PR TITLE
Rename to Underfloor Heating Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Home Assistant UFH Controller
+# Underfloor Heating Controller
 
-A Home Assistant custom integration for underfloor heating controller.
+A Home Assistant custom integration for multi-zone underfloor heating control with PID-based temperature regulation.
 
 ## Installation
 
 ### HACS (Recommended)
 
 1. Add this repository to HACS as a custom repository
-2. Search for "UFH Controller" in HACS
+2. Search for "Underfloor Heating Controller" in HACS
 3. Install the integration
 4. Restart Home Assistant
 
@@ -20,7 +20,7 @@ A Home Assistant custom integration for underfloor heating controller.
 
 1. Go to Settings -> Devices & Services
 2. Click "Add Integration"
-3. Search for "Home Assistant UFH Controller"
+3. Search for "Underfloor Heating Controller"
 4. Follow the setup wizard
 
 ## Documentation

--- a/custom_components/ufh_controller/__init__.py
+++ b/custom_components/ufh_controller/__init__.py
@@ -1,5 +1,5 @@
 """
-Custom integration to integrate UFH Controller with Home Assistant.
+Custom integration to integrate Underfloor Heating Controller with Home Assistant.
 
 For more details about this integration, please refer to
 https://github.com/lnagel/hass-ufh-controller
@@ -45,8 +45,8 @@ async def async_setup_entry(
     hass: HomeAssistant,
     entry: UFHControllerConfigEntry,
 ) -> bool:
-    """Set up UFH Controller from a config entry."""
-    LOGGER.debug("Setting up UFH Controller entry: %s", entry.entry_id)
+    """Set up Underfloor Heating Controller from a config entry."""
+    LOGGER.debug("Setting up Underfloor Heating Controller entry: %s", entry.entry_id)
 
     # Ensure controller subentry exists (auto-create if missing)
     await _async_ensure_controller_subentry(hass, entry)
@@ -90,7 +90,7 @@ async def _async_ensure_controller_subentry(
     # Create controller subentry with timing data
     # Try to migrate timing from options if available, otherwise use defaults
     timing = entry.options.get("timing", DEFAULT_TIMING)
-    controller_name = entry.data.get("name", "UFH Controller")
+    controller_name = entry.data.get("name", "Underfloor Heating Controller")
     controller_subentry = ConfigSubentry(
         data=MappingProxyType({"timing": timing}),
         subentry_type=SUBENTRY_TYPE_CONTROLLER,
@@ -107,7 +107,7 @@ async def async_unload_entry(
     entry: UFHControllerConfigEntry,
 ) -> bool:
     """Handle removal of an entry."""
-    LOGGER.debug("Unloading UFH Controller entry: %s", entry.entry_id)
+    LOGGER.debug("Unloading Underfloor Heating Controller entry: %s", entry.entry_id)
 
     # Save state before unloading
     coordinator = entry.runtime_data.coordinator

--- a/custom_components/ufh_controller/binary_sensor.py
+++ b/custom_components/ufh_controller/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Binary sensor platform for UFH Controller."""
+"""Binary sensor platform for Underfloor Heating Controller."""
 
 from __future__ import annotations
 

--- a/custom_components/ufh_controller/climate.py
+++ b/custom_components/ufh_controller/climate.py
@@ -1,4 +1,4 @@
-"""Climate platform for UFH Controller."""
+"""Climate platform for Underfloor Heating Controller."""
 
 from __future__ import annotations
 

--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for UFH Controller."""
+"""Config flow for Underfloor Heating Controller."""
 
 from __future__ import annotations
 
@@ -462,7 +462,7 @@ def build_zone_data(user_input: dict[str, Any]) -> dict[str, Any]:
 
 
 class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Config flow for UFH Controller."""
+    """Config flow for Underfloor Heating Controller."""
 
     VERSION = 1
 
@@ -483,7 +483,9 @@ class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(controller_id)
             self._abort_if_unique_id_configured()
 
-            LOGGER.debug("Creating UFH Controller entry: %s", controller_id)
+            LOGGER.debug(
+                "Creating Underfloor Heating Controller entry: %s", controller_id
+            )
 
             return self.async_create_entry(
                 title=user_input[CONF_NAME],
@@ -543,7 +545,7 @@ class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle options flow for UFH Controller."""
+    """Handle options flow for Underfloor Heating Controller."""
 
     async def async_step_init(
         self,

--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -1,4 +1,4 @@
-"""Constants for UFH Controller."""
+"""Constants for Underfloor Heating Controller."""
 
 from enum import StrEnum
 from logging import Logger, getLogger

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -1,4 +1,4 @@
-"""DataUpdateCoordinator for UFH Controller."""
+"""DataUpdateCoordinator for Underfloor Heating Controller."""
 
 from __future__ import annotations
 
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 
 class UFHControllerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Class to manage fetching UFH Controller data."""
+    """Class to manage fetching Underfloor Heating Controller data."""
 
     config_entry: UFHControllerConfigEntry
 
@@ -282,7 +282,7 @@ class UFHControllerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Clear fail-safe if previously activated
         if self._fail_safe_activated:
             self._fail_safe_activated = False
-            LOGGER.info("UFH Controller recovered from fail-safe mode")
+            LOGGER.info("Underfloor Heating Controller recovered from fail-safe mode")
 
         # Dismiss any existing notification
         if self._notification_created:
@@ -333,8 +333,8 @@ class UFHControllerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._fail_safe_activated = True
         self._status = ControllerStatus.FAIL_SAFE
         LOGGER.error(
-            "UFH Controller entering fail-safe mode after %d consecutive failures "
-            "and no successful update for over 1 hour",
+            "Underfloor Heating Controller entering fail-safe mode after %d "
+            "consecutive failures and no successful update for over 1 hour",
             self._consecutive_failures,
         )
 
@@ -355,12 +355,12 @@ class UFHControllerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "create",
                 {
                     "message": (
-                        f"The UFH Controller has experienced "
+                        f"The Underfloor Heating Controller has experienced "
                         f"{self._consecutive_failures} consecutive Recorder query "
                         f"failures. The controller is operating in {mode_text} mode. "
                         f"Check that the Recorder component is functioning correctly."
                     ),
-                    "title": "UFH Controller: Recorder Failure",
+                    "title": "Underfloor Heating Controller: Recorder Failure",
                     "notification_id": f"{DOMAIN}_recorder_failure",
                 },
             )

--- a/custom_components/ufh_controller/core/__init__.py
+++ b/custom_components/ufh_controller/core/__init__.py
@@ -1,4 +1,4 @@
-"""Core control logic for UFH Controller."""
+"""Core control logic for Underfloor Heating Controller."""
 
 from .controller import (
     ControllerConfig,

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -1,5 +1,5 @@
 """
-Controller logic for UFH Controller.
+Controller logic for Underfloor Heating Controller.
 
 This module provides the main HeatingController class that orchestrates
 zone control, operation modes, and heat request aggregation.

--- a/custom_components/ufh_controller/core/history.py
+++ b/custom_components/ufh_controller/core/history.py
@@ -1,5 +1,5 @@
 """
-Historical state query helpers for UFH Controller.
+Historical state query helpers for Underfloor Heating Controller.
 
 This module provides functions for querying historical entity states
 from Home Assistant's Recorder component for time-windowed calculations.

--- a/custom_components/ufh_controller/core/pid.py
+++ b/custom_components/ufh_controller/core/pid.py
@@ -1,5 +1,5 @@
 """
-PID controller implementation for UFH Controller.
+PID controller implementation for Underfloor Heating Controller.
 
 This module provides a pure Python PID controller with anti-windup
 for temperature regulation in heating zones.

--- a/custom_components/ufh_controller/core/zone.py
+++ b/custom_components/ufh_controller/core/zone.py
@@ -1,5 +1,5 @@
 """
-Zone state and decision logic for UFH Controller.
+Zone state and decision logic for Underfloor Heating Controller.
 
 This module contains the zone state dataclasses and decision functions
 for determining valve actions based on quota-based scheduling.

--- a/custom_components/ufh_controller/data.py
+++ b/custom_components/ufh_controller/data.py
@@ -1,4 +1,4 @@
-"""Custom types for UFH Controller."""
+"""Custom types for Underfloor Heating Controller."""
 
 from __future__ import annotations
 
@@ -16,6 +16,6 @@ type UFHControllerConfigEntry = ConfigEntry[UFHControllerData]
 
 @dataclass
 class UFHControllerData:
-    """Data for the UFH Controller integration."""
+    """Data for the Underfloor Heating Controller integration."""
 
     coordinator: UFHControllerDataUpdateCoordinator

--- a/custom_components/ufh_controller/device.py
+++ b/custom_components/ufh_controller/device.py
@@ -1,4 +1,4 @@
-"""Device helpers for UFH Controller."""
+"""Device helpers for Underfloor Heating Controller."""
 
 from __future__ import annotations
 
@@ -18,8 +18,8 @@ def get_controller_device_info(
     """Get device info for the main controller device."""
     return DeviceInfo(
         identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
-        name=coordinator.config_entry.data.get("name", "UFH Controller"),
-        manufacturer="UFH Controller",
+        name=coordinator.config_entry.data.get("name", "Underfloor Heating Controller"),
+        manufacturer="Underfloor Heating Controller",
         model="Heating Controller",
         sw_version="0.1.0",
     )
@@ -34,7 +34,7 @@ def get_zone_device_info(
     return DeviceInfo(
         identifiers={(DOMAIN, f"{coordinator.config_entry.entry_id}_{zone_id}")},
         name=zone_name,
-        manufacturer="UFH Controller",
+        manufacturer="Underfloor Heating Controller",
         model="Heating Zone",
         via_device=(DOMAIN, coordinator.config_entry.entry_id),
     )

--- a/custom_components/ufh_controller/entity.py
+++ b/custom_components/ufh_controller/entity.py
@@ -1,4 +1,4 @@
-"""Base entity classes for UFH Controller."""
+"""Base entity classes for Underfloor Heating Controller."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ def get_controller_subentry_id(entry: UFHControllerConfigEntry) -> str | None:
 
 
 class UFHControllerEntity(CoordinatorEntity[UFHControllerDataUpdateCoordinator]):
-    """Base class for controller-level UFH Controller entities."""
+    """Base class for controller-level Underfloor Heating Controller entities."""
 
     _attr_has_entity_name = True
 
@@ -39,7 +39,7 @@ class UFHControllerEntity(CoordinatorEntity[UFHControllerDataUpdateCoordinator])
 
 
 class UFHControllerZoneEntity(CoordinatorEntity[UFHControllerDataUpdateCoordinator]):
-    """Base class for zone-level UFH Controller entities."""
+    """Base class for zone-level Underfloor Heating Controller entities."""
 
     _attr_has_entity_name = True
 

--- a/custom_components/ufh_controller/manifest.json
+++ b/custom_components/ufh_controller/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ufh_controller",
-  "name": "UFH Controller",
+  "name": "Underfloor Heating Controller",
   "codeowners": [
     "@lnagel"
   ],

--- a/custom_components/ufh_controller/select.py
+++ b/custom_components/ufh_controller/select.py
@@ -1,4 +1,4 @@
-"""Select platform for UFH Controller."""
+"""Select platform for Underfloor Heating Controller."""
 
 from __future__ import annotations
 

--- a/custom_components/ufh_controller/sensor.py
+++ b/custom_components/ufh_controller/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for UFH Controller."""
+"""Sensor platform for Underfloor Heating Controller."""
 
 from __future__ import annotations
 

--- a/custom_components/ufh_controller/strings.json
+++ b/custom_components/ufh_controller/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Set up UFH Controller",
+        "title": "Set up Underfloor Heating Controller",
         "description": "Configure your underfloor heating controller.",
         "data": {
           "name": "Controller name",

--- a/custom_components/ufh_controller/switch.py
+++ b/custom_components/ufh_controller/switch.py
@@ -1,4 +1,4 @@
-"""Switch platform for UFH Controller."""
+"""Switch platform for Underfloor Heating Controller."""
 
 from __future__ import annotations
 

--- a/custom_components/ufh_controller/translations/en.json
+++ b/custom_components/ufh_controller/translations/en.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Set up UFH Controller",
+        "title": "Set up Underfloor Heating Controller",
         "description": "Configure your underfloor heating controller.",
         "data": {
           "name": "Controller name",

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -252,7 +252,7 @@ On entry setup, a **controller subentry** is automatically created to:
 Zones are managed as **config subentries**. Users interact with zones through:
 
 **Adding a Zone:**
-- Navigate to: Settings → Devices & Services → UFH Controller → "+ Add Heating Zone"
+- Navigate to: Settings → Devices & Services → Underfloor Heating Controller → "+ Add Heating Zone"
 - Or: Device page → Controller device → "Add Heating Zone" button
 
 | Field | Type | Required | Description |
@@ -279,7 +279,7 @@ Zones are managed as **config subentries**. Users interact with zones through:
 
 ### 4.3 Options Flow (Timing Settings)
 
-Accessed via: Settings → Devices & Services → UFH Controller → Configure
+Accessed via: Settings → Devices & Services → Underfloor Heating Controller → Configure
 
 The options flow provides access to **timing parameters** that apply to the entire controller:
 
@@ -1037,7 +1037,7 @@ repos:
 
 ## 13. Configuration Reference
 
-This section provides detailed documentation for all configuration parameters in the UFH Controller. Each parameter directly affects how the heating system operates.
+This section provides detailed documentation for all configuration parameters in the Underfloor Heating Controller. Each parameter directly affects how the heating system operates.
 
 ### 13.1 Timing Parameters
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "UFH Controller",
+    "name": "Underfloor Heating Controller",
     "homeassistant": "2025.10.0",
     "hacs": "2.0.5"
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for UFH Controller integration."""
+"""Tests for Underfloor Heating Controller integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Common fixtures for UFH Controller tests."""
+"""Common fixtures for Underfloor Heating Controller tests."""
 
 from collections.abc import Generator
 from typing import Any

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,4 +1,4 @@
-"""Tests for UFH Controller climate platform."""
+"""Tests for Underfloor Heating Controller climate platform."""
 
 from unittest.mock import patch
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Tests for UFH Controller config flow."""
+"""Tests for Underfloor Heating Controller config flow."""
 
 from typing import Any
 from unittest.mock import patch

--- a/tests/test_coordinator_persistence.py
+++ b/tests/test_coordinator_persistence.py
@@ -1,4 +1,4 @@
-"""Tests for UFH Controller coordinator persistence."""
+"""Tests for Underfloor Heating Controller coordinator persistence."""
 
 from unittest.mock import AsyncMock, patch
 

--- a/tests/test_entity_unavailability.py
+++ b/tests/test_entity_unavailability.py
@@ -1,4 +1,4 @@
-"""Tests for entity unavailability handling in UFH Controller."""
+"""Tests for entity unavailability handling in Underfloor Heating Controller."""
 
 from typing import Any
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,4 @@
-"""Test UFH Controller setup and unload."""
+"""Test Underfloor Heating Controller setup and unload."""
 
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,4 +1,4 @@
-"""Tests for UFH Controller select platform."""
+"""Tests for Underfloor Heating Controller select platform."""
 
 from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,4 +1,4 @@
-"""Tests for UFH Controller sensor platform."""
+"""Tests for Underfloor Heating Controller sensor platform."""
 
 import pytest
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,4 +1,4 @@
-"""Tests for UFH Controller switch platform."""
+"""Tests for Underfloor Heating Controller switch platform."""
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (


### PR DESCRIPTION
## Summary

- Rename the integration display name from "UFH Controller" to "Underfloor Heating Controller"
- Spell out the acronym for better discoverability when browsing integration lists
- Update all user-visible strings, log messages, and documentation

## Notes

- The domain `ufh_controller` remains unchanged to preserve entity IDs and existing configurations
- No functional changes - purely a naming update

## Test plan

- [x] All existing tests pass (287 tests)
- [x] Ruff format and lint checks pass
- [x] Type checking passes
- [ ] Verify integration appears as "Underfloor Heating Controller" in HACS search
- [ ] Verify config flow shows updated title

🤖 Generated with [Claude Code](https://claude.com/claude-code)