### PR TITLE
Implement hybrid config reload to avoid entity state resets

### DIFF
--- a/custom_components/ufh_controller/__init__.py
+++ b/custom_components/ufh_controller/__init__.py
@@ -57,17 +57,20 @@ async def async_setup_entry(
     entry.runtime_data = UFHControllerData(coordinator=coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+    entry.async_on_unload(entry.add_update_listener(_async_handle_config_update))
 
-    # Listen for subentry updates and reload when zone subentries change
+    # Listen for subentry updates and handle intelligently
     async def _async_handle_subentry_update(event: Any) -> None:
         """Handle subentry update event."""
         if event.data.get("entry_id") != entry.entry_id:
             return
         subentry_type = event.data.get("subentry_type")
-        if subentry_type == SUBENTRY_TYPE_ZONE:
-            LOGGER.debug("Zone subentry updated, scheduling reload")
-            await hass.config_entries.async_reload(entry.entry_id)
+        if subentry_type in (SUBENTRY_TYPE_ZONE, SUBENTRY_TYPE_CONTROLLER):
+            LOGGER.debug(
+                "%s subentry updated, handling config update",
+                subentry_type,
+            )
+            await _async_handle_config_update(hass, entry)
 
     entry.async_on_unload(
         hass.bus.async_listen("config_subentry_updated", _async_handle_subentry_update)
@@ -115,6 +118,52 @@ async def async_unload_entry(
         await coordinator.async_save_state()
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def _async_handle_config_update(
+    hass: HomeAssistant,
+    entry: UFHControllerConfigEntry,
+) -> None:
+    """
+    Handle config entry update intelligently.
+
+    Detects structural changes (zones added/removed) vs parameter changes
+    (timing, PID, setpoints). Structural changes require full reload, while
+    parameter changes can be applied in-place without entity recreation.
+    """
+    # Check if entry has runtime data (might not during initial setup)
+    if not hasattr(entry, "runtime_data") or entry.runtime_data is None:
+        LOGGER.debug("No runtime data, performing full reload")
+        await hass.config_entries.async_reload(entry.entry_id)
+        return
+
+    coordinator = entry.runtime_data.coordinator
+
+    # Get current zone IDs from coordinator
+    old_zone_ids = set(coordinator.controller.zone_ids)
+
+    # Get new zone IDs from updated config entry subentries
+    new_zone_ids = {
+        subentry.data["id"]
+        for subentry in entry.subentries.values()
+        if subentry.subentry_type == SUBENTRY_TYPE_ZONE
+    }
+
+    # Detect structural change: zones added or removed
+    if old_zone_ids != new_zone_ids:
+        added = new_zone_ids - old_zone_ids
+        removed = old_zone_ids - new_zone_ids
+        LOGGER.info(
+            "Structural change detected: zones added=%s, removed=%s, "
+            "performing full reload",
+            added or "none",
+            removed or "none",
+        )
+        await hass.config_entries.async_reload(entry.entry_id)
+    else:
+        # Just parameter changes: update in-place
+        LOGGER.debug("Parameter change detected, updating config in-place")
+        await coordinator.async_reload_config()
 
 
 async def async_reload_entry(

--- a/tests/config/test_init.py
+++ b/tests/config/test_init.py
@@ -1,7 +1,18 @@
 """Test Underfloor Heating Controller setup and unload."""
 
+from types import MappingProxyType
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.config_entries import ConfigSubentry
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ufh_controller.const import (
+    DEFAULT_PID,
+    SUBENTRY_TYPE_CONTROLLER,
+    SUBENTRY_TYPE_ZONE,
+)
+from custom_components.ufh_controller.core.pid import PIDState
 
 
 async def test_setup_entry(
@@ -56,3 +67,162 @@ async def test_reload_entry(
     # Reload the entry
     assert await hass.config_entries.async_reload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_config_update_parameter_change_in_place(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test parameter change updates config in-place without entity recreation."""
+    mock_config_entry.add_to_hass(hass)
+    # Set up temperature sensor so refresh cycle can read it
+    hass.states.async_set("sensor.zone1_temp", "20.5")
+
+    # Setup entry
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+
+    # Set up zone with PID state
+    zone_runtime = coordinator.controller.get_zone_runtime("zone1")
+    zone_runtime.state.setpoint = 22.0
+    zone_runtime.pid.set_state(
+        PIDState(
+            error=-1.5,
+            p_term=15.0,
+            i_term=10.0,
+            d_term=5.0,
+            duty_cycle=30.0,
+        )
+    )
+
+    # Find zone subentry
+    zone_subentry = None
+    for subentry in mock_config_entry.subentries.values():
+        if subentry.subentry_type == SUBENTRY_TYPE_ZONE:
+            zone_subentry = subentry
+            break
+    assert zone_subentry is not None
+
+    # Change PID parameters in zone subentry (parameter change, not structural)
+    new_pid = {**DEFAULT_PID, "kp": 20.0}  # Change Kp parameter
+    updated_data = {**zone_subentry.data, "pid": new_pid}
+
+    # Patch async_reload to verify it's NOT called
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload"
+    ) as mock_reload:
+        # Update subentry data (simulates user changing config in UI)
+        hass.config_entries.async_update_subentry(
+            mock_config_entry,
+            zone_subentry,
+            data=updated_data,
+        )
+        await hass.async_block_till_done()
+
+        # Verify async_reload was NOT called (in-place update used instead)
+        mock_reload.assert_not_called()
+
+    # Verify runtime state was preserved and new PID parameters are applied
+    zone_runtime_after = coordinator.controller.get_zone_runtime("zone1")
+    assert zone_runtime_after.state.setpoint == 22.0
+    # Temperature will be read from sensor during refresh
+    assert zone_runtime_after.state.current is not None
+    assert zone_runtime_after.pid.state is not None
+
+    # Verify new PID parameters are applied
+    assert zone_runtime_after.config.kp == 20.0
+
+    # Note: duty_cycle will be recalculated with new kp during refresh
+    # This is expected - the config update preserves state during rebuild,
+    # but the refresh recalculates PID output with new parameters
+
+
+async def test_config_update_structural_change_full_reload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test structural change (zone added) triggers full reload."""
+    mock_config_entry.add_to_hass(hass)
+    hass.states.async_set("sensor.zone1_temp", "20.5")
+
+    # Setup entry
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Patch async_reload to verify it IS called for structural changes
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload",
+        new_callable=AsyncMock,
+    ) as mock_reload:
+        # Add a new zone (structural change)
+        new_zone_data = {
+            "id": "zone2",
+            "name": "Test Zone 2",
+            "circuit_type": "regular",
+            "temp_sensor": "sensor.zone2_temp",
+            "valve_switch": "switch.zone2_valve",
+            "setpoint": DEFAULT_PID,
+            "pid": DEFAULT_PID,
+            "window_sensors": [],
+        }
+        new_subentry = ConfigSubentry(
+            data=MappingProxyType(new_zone_data),
+            subentry_type=SUBENTRY_TYPE_ZONE,
+            title="Test Zone 2",
+            unique_id="zone2",
+        )
+
+        hass.config_entries.async_add_subentry(mock_config_entry, new_subentry)
+        await hass.async_block_till_done()
+
+        # Verify async_reload WAS called (full reload for structural change)
+        mock_reload.assert_called_once_with(mock_config_entry.entry_id)
+
+
+async def test_config_update_controller_params_in_place(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test controller parameter change (timing) updates in-place."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Setup entry (this creates controller subentry)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+
+    # Find controller subentry (created during setup)
+    controller_subentry = None
+    for subentry in mock_config_entry.subentries.values():
+        if subentry.subentry_type == SUBENTRY_TYPE_CONTROLLER:
+            controller_subentry = subentry
+            break
+    assert controller_subentry is not None
+
+    # Change timing parameter
+    new_timing = {
+        **controller_subentry.data["timing"],
+        "controller_loop_interval": 45,  # Change from 30 to 45
+    }
+    updated_data = {**controller_subentry.data, "timing": new_timing}
+
+    # Patch async_reload to verify it's NOT called
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload"
+    ) as mock_reload:
+        # Update controller subentry
+        hass.config_entries.async_update_subentry(
+            mock_config_entry,
+            controller_subentry,
+            data=updated_data,
+        )
+        await hass.async_block_till_done()
+
+        # Verify async_reload was NOT called (in-place update)
+        mock_reload.assert_not_called()
+
+    # Verify new timing parameter is applied
+    assert coordinator.controller.config.timing.controller_loop_interval == 45

--- a/tests/scenarios/test_coordinator_persistence.py
+++ b/tests/scenarios/test_coordinator_persistence.py
@@ -119,9 +119,8 @@ async def test_coordinator_save_state_format(
         nonlocal saved_data
         saved_data = data
 
-    with patch(
-        "homeassistant.helpers.storage.Store.async_save", side_effect=capture_save
-    ):
+    # Patch the coordinator's store instance directly
+    with patch.object(coordinator._store, "async_save", side_effect=capture_save):
         await coordinator.async_save_state()
 
     assert saved_data is not None
@@ -762,9 +761,8 @@ async def test_flush_enabled_saved_in_state(
         nonlocal saved_data
         saved_data = data
 
-    with patch(
-        "homeassistant.helpers.storage.Store.async_save", side_effect=capture_save
-    ):
+    # Patch the coordinator's store instance directly
+    with patch.object(coordinator._store, "async_save", side_effect=capture_save):
         await coordinator.async_save_state()
 
     assert saved_data is not None
@@ -774,11 +772,11 @@ async def test_flush_enabled_saved_in_state(
     # Also test with False
     coordinator.controller.state.flush_enabled = False
 
-    with patch(
-        "homeassistant.helpers.storage.Store.async_save", side_effect=capture_save
-    ):
+    # Patch the coordinator's store instance directly
+    with patch.object(coordinator._store, "async_save", side_effect=capture_save):
         await coordinator.async_save_state()
 
+    assert saved_data is not None
     assert saved_data["flush_enabled"] is False
 
 


### PR DESCRIPTION
This change optimizes config reloading to avoid recreating entities when
only parameters change (PID, timing, setpoints), while still performing
a full reload when zones are added or removed.

Key changes:
- Add async_reload_config() method to coordinator for in-place updates
- Implement _async_handle_config_update() to detect structural vs
  parameter changes
- Preserve runtime state (PID state, setpoints, enabled flags) during
  parameter updates
- Add comprehensive tests for all reload scenarios

Benefits:
- No entity state resets when tuning parameters daily
- Faster updates (no unload/reload cycle for parameter changes)
- Full reload still happens when zones are added/removed (rare)
- Preserves all runtime state during parameter updates