### PR TITLE
Hide zone analysis entities by default

### DIFF
--- a/custom_components/ufh_controller/binary_sensor.py
+++ b/custom_components/ufh_controller/binary_sensor.py
@@ -99,6 +99,7 @@ class UFHZoneBinarySensor(UFHControllerZoneEntity, BinarySensorEntity):
     """Binary sensor entity for zone status."""
 
     entity_description: UFHZoneBinarySensorEntityDescription
+    _attr_entity_registry_visible_default = False
 
     def __init__(
         self,
@@ -146,6 +147,7 @@ class UFHControllerStatusSensor(UFHControllerEntity, BinarySensorEntity):
 
     _attr_translation_key = "status"
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_registry_visible_default = False
 
     def __init__(
         self,
@@ -188,6 +190,7 @@ class UFHFlushRequestSensor(UFHControllerEntity, BinarySensorEntity):
     _attr_translation_key = "flush_request"
     _attr_device_class = BinarySensorDeviceClass.HEAT
     _attr_name = "Flush Request"
+    _attr_entity_registry_visible_default = False
 
     def __init__(
         self,

--- a/custom_components/ufh_controller/select.py
+++ b/custom_components/ufh_controller/select.py
@@ -40,6 +40,7 @@ class UFHModeSelect(UFHControllerEntity, SelectEntity):
 
     _attr_translation_key = "mode"
     _attr_options: ClassVar[list[str]] = [mode.value for mode in OperationMode]
+    _attr_entity_registry_visible_default = False
 
     def __init__(
         self,

--- a/custom_components/ufh_controller/sensor.py
+++ b/custom_components/ufh_controller/sensor.py
@@ -125,6 +125,7 @@ class UFHZoneSensor(UFHControllerZoneEntity, SensorEntity):
     """Sensor entity for zone metrics."""
 
     entity_description: UFHZoneSensorEntityDescription
+    _attr_entity_registry_visible_default = False
 
     def __init__(
         self,
@@ -170,6 +171,7 @@ class UFHRequestingZonesSensor(UFHControllerEntity, SensorEntity):
     _attr_translation_key = "requesting_zones"
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "zones"
+    _attr_entity_registry_visible_default = False
 
     def __init__(
         self,

--- a/custom_components/ufh_controller/switch.py
+++ b/custom_components/ufh_controller/switch.py
@@ -44,6 +44,7 @@ class UFHFlushEnabledSwitch(UFHControllerEntity, SwitchEntity):
 
     _attr_translation_key = "flush_enabled"
     _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_entity_registry_visible_default = False
 
     def __init__(
         self,


### PR DESCRIPTION
Set entity_registry_visible_default=False on all non-climate entities (sensors, binary sensors, select, and switch) to prevent them from cluttering auto-generated dashboards. Climate entities remain visible as they are the primary user-facing controls.

This affects:
- Zone sensors (duty_cycle, PID terms)
- Controller sensors (requesting_zones)
- Zone binary sensors (blocked, heat_request)
- Controller binary sensors (status, flush_request)
- Controller select (mode)
- Controller switch (flush_enabled)