### PR TITLE
Set flush request timing to activate only after DHW ends

### DIFF
--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -457,7 +457,7 @@ class UFHControllerDataUpdateCoordinator(
                     self._controller.state.flush_until,
                 )
 
-        # Clear flush_until when DHW starts (flush only happens after DHW ends)
+        # Clear flush_until when DHW starts
         if current_dhw_active and not self._prev_dhw_active:
             self._controller.state.flush_until = None
 

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -85,8 +85,8 @@ def compute_flush_request(
 
     Flush circuits activate when:
     - flush_enabled is True (user has enabled the feature)
-    - DHW is NOT currently active (flush only starts AFTER DHW ends)
-    - Post-DHW timer is active (within flush_until period)
+    - DHW is NOT currently active
+    - Post-DHW timer is active
     - No regular circuits are currently ON
 
     Args:
@@ -103,11 +103,9 @@ def compute_flush_request(
     if not flush_enabled:
         return False
 
-    # Flush only activates AFTER DHW ends, not during DHW
     if dhw_active:
         return False
 
-    # Check if within post-DHW flush period
     if flush_until is None or now >= flush_until:
         return False
 

--- a/docs/control_algorithm.md
+++ b/docs/control_algorithm.md
@@ -55,7 +55,7 @@ This prevents the common problem of integral windup where the integral term accu
 
 The zone evaluation follows a priority-based decision tree:
 
-1. **Flush circuit priority:** If flush is enabled and DHW has recently ended (within `flush_duration`, default 8 minutes) with no regular circuits currently running, flush circuits turn on to capture latent heat from the pipes. Flush circuits do NOT activate while DHW is active — only after DHW switches from active to inactive.
+1. **Flush circuit priority:** If flush is enabled and DHW has recently ended with no regular circuits currently running, flush circuits turn on to capture latent heat from the boiler.
 
 2. **End-of-period freeze:** When less than `min_run_time` remains in the observation period, valve positions are frozen to prevent unnecessary cycling at period boundaries.
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -16,13 +16,13 @@ All controller entities belong to a device named after the controller (user-defi
 **Note:** The flush enabled switch and flush request sensor are only created when `dhw_active_entity` is configured, as the DHW latent heat capture feature requires DHW state input to function.
 
 **Flush Enabled Behavior:**
-- **Enabled:** Flush-type circuits can turn on for a configurable period after DHW ends (`flush_duration`, default 8 minutes) to capture latent heat from the pipes (only when no regular circuits are currently running with valve ON).
+- **Enabled:** Flush-type circuits can turn on for a configurable period after DHW ends (`flush_duration`) to capture latent heat (only when no regular circuits are currently running with valve ON).
 - **Disabled:** Flush-type circuits behave like regular circuits — no special DHW priority.
 - **DHW priority for regular zones is independent of this setting.** Regular zones that are OFF cannot turn ON during DHW heating regardless of the flush enabled state. This switch only controls whether flush circuits get special treatment.
 
 **Flush Request Behavior:**
 The flush request sensor indicates when flush circuits are actively capturing heat:
-- **ON:** Only during the post-DHW flush period (after DHW switches from active to inactive)
+- **ON:** During the post-DHW flush period
 - **OFF:** When DHW is active or not within the post-DHW flush period
 - **Requires flush_enabled:** The sensor only reports ON if `flush_enabled` switch is also on
 

--- a/tests/integration/test_binary_sensor.py
+++ b/tests/integration/test_binary_sensor.py
@@ -297,19 +297,14 @@ async def test_flush_request_off_during_dhw_with_flush_enabled(
     mock_config_entry: MockConfigEntry,
     mock_temp_sensor: None,
 ) -> None:
-    """
-    Test flush_request is OFF during DHW active.
-
-    Flush only activates AFTER DHW ends, not during DHW.
-    """
+    """Test flush_request is OFF during DHW active."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     coordinator = mock_config_entry.runtime_data.coordinator
 
-    # Set DHW active and flush enabled - flush should still be OFF
-    # because flush only activates AFTER DHW switches from active to inactive
+    # Set DHW active and flush enabled
     hass.states.async_set("binary_sensor.dhw_active", "on")
     coordinator.controller.state.flush_enabled = True
     await coordinator.async_refresh()

--- a/tests/unit/test_flush_request.py
+++ b/tests/unit/test_flush_request.py
@@ -19,12 +19,12 @@ FLUSH_UNTIL_EXPIRED = "expired"
         (False, False, FLUSH_UNTIL_FUTURE, False, False),
         # No post-DHW timer returns False (even if flush enabled)
         (True, False, None, False, False),
-        # DHW currently active returns False (flush only starts AFTER DHW ends)
+        # DHW currently active returns False
         (True, True, None, False, False),
         (True, True, FLUSH_UNTIL_FUTURE, False, False),
         # Post-DHW period (timer active) + no regular ON = True
         (True, False, FLUSH_UNTIL_FUTURE, False, True),
-        # Post-DHW period + regular ON = False (regular zones block flush)
+        # Post-DHW period + regular ON = False
         (True, False, FLUSH_UNTIL_FUTURE, True, False),
         # Post-DHW period expired = False
         (True, False, FLUSH_UNTIL_EXPIRED, False, False),


### PR DESCRIPTION
Previously, flush request would activate during DHW active OR during the
post-DHW period. After testing, it was confirmed that flush should only
activate AFTER DHW switches from active to inactive, and remain active
for 8 minutes (the configured flush_duration).

Changes:
- Update compute_flush_request() to return False when DHW is active
- Flush only activates during the post-DHW timer period
- Update documentation in entities.md and control_algorithm.md
- Update unit tests and integration tests to reflect new behavior