### PR TITLE
Centralize version management in const module

### DIFF
--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from enum import StrEnum
 from logging import Logger, getLogger
+from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -15,6 +17,12 @@ if TYPE_CHECKING:
 LOGGER: Logger = getLogger(__package__)
 
 DOMAIN = "ufh_controller"
+
+# Load version from manifest.json once at module load
+MANIFEST_PATH = Path(__file__).parent / "manifest.json"
+VERSION = json.loads(MANIFEST_PATH.read_text())["version"]
+
+# Subentry types for config entry organization
 SUBENTRY_TYPE_CONTROLLER = "controller"
 SUBENTRY_TYPE_ZONE = "zone"
 

--- a/custom_components/ufh_controller/device.py
+++ b/custom_components/ufh_controller/device.py
@@ -2,20 +2,14 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN
+from .const import DOMAIN, VERSION
 
 if TYPE_CHECKING:
     from .coordinator import UFHControllerDataUpdateCoordinator
-
-# Load version from manifest.json once at module load
-_MANIFEST_PATH = Path(__file__).parent / "manifest.json"
-_VERSION = json.loads(_MANIFEST_PATH.read_text())["version"]
 
 
 def get_controller_device_info(
@@ -27,7 +21,7 @@ def get_controller_device_info(
         name=coordinator.config_entry.data.get("name", "Underfloor Heating Controller"),
         manufacturer="Underfloor Heating Controller",
         model="Heating Controller",
-        sw_version=_VERSION,
+        sw_version=VERSION,
     )
 
 

--- a/tests/unit/test_const.py
+++ b/tests/unit/test_const.py
@@ -1,0 +1,22 @@
+"""Test const module."""
+
+import json
+
+from custom_components.ufh_controller.const import MANIFEST_PATH, VERSION
+
+
+class TestVersion:
+    """Test cases for VERSION constant."""
+
+    def test_manifest_path_exists(self) -> None:
+        """MANIFEST_PATH should point to an existing file."""
+        assert MANIFEST_PATH.exists()
+
+    def test_version_matches_manifest(self) -> None:
+        """VERSION should match the version in manifest.json."""
+        manifest = json.loads(MANIFEST_PATH.read_text())
+        assert manifest["version"] == VERSION
+
+    def test_version_is_string(self) -> None:
+        """VERSION should be a string."""
+        assert isinstance(VERSION, str)


### PR DESCRIPTION
## Summary
Refactored version management by moving the manifest.json version loading logic from `device.py` to `const.py`, making it a centralized constant that can be reused across the codebase.

## Key Changes
- **const.py**: Added `MANIFEST_PATH` and `VERSION` constants that load the version from manifest.json at module initialization
- **device.py**: Removed duplicate manifest loading logic and now imports `VERSION` from const module
- **tests/unit/test_const.py**: Added new test file with three test cases to verify:
  - The manifest file path exists
  - The VERSION constant matches the manifest.json version
  - The VERSION is a string type

## Benefits
- **DRY principle**: Eliminates code duplication across modules
- **Single source of truth**: Version is now defined in one place and can be imported wherever needed
- **Better testability**: Version loading logic is now testable through the const module
- **Improved maintainability**: Future modules needing the version can simply import from const