### PR TITLE
Add valve unavailability as degraded/fail-safe trigger

### DIFF
--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -67,7 +67,7 @@ class ZoneStatus(StrEnum):
 
     INITIALIZING = "initializing"  # Zone starting up, awaiting first successful update
     NORMAL = "normal"  # Zone operating normally with valid temperature readings
-    DEGRADED = "degraded"  # Temp sensor unavailable or Recorder query failing
+    DEGRADED = "degraded"  # Temp sensor, valve, or Recorder unavailable
     FAIL_SAFE = "fail_safe"  # No successful update for >1 hour, valve forced closed
 
 

--- a/custom_components/ufh_controller/core/zone.py
+++ b/custom_components/ufh_controller/core/zone.py
@@ -294,6 +294,7 @@ class ZoneRuntime:
         *,
         temp_unavailable: bool,
         recorder_failure: bool,
+        valve_unavailable: bool,
         fail_safe_timeout: int,
     ) -> ZoneStatusTransition:
         """
@@ -306,13 +307,14 @@ class ZoneRuntime:
             now: Current timestamp.
             temp_unavailable: Whether temperature reading is unavailable.
             recorder_failure: Whether Recorder query failed.
+            valve_unavailable: Whether valve entity is unavailable or unknown.
             fail_safe_timeout: Seconds before entering fail-safe mode.
 
         Returns:
             ZoneStatusTransition indicating what happened (for caller to log).
 
         """
-        if temp_unavailable or recorder_failure:
+        if temp_unavailable or recorder_failure or valve_unavailable:
             # Zone has a failure - increment counter and check for fail-safe
             self.state.consecutive_failures += 1
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ Coordinator._async_update_data()
     │       ├─► Query Recorder for historical averages
     │       ├─► zone.update_historical(period_avg, open_avg, ...)
     │       ├─► Sync valve state from HA entity
-    │       └─► zone.update_failure_state(now, temp_unavail, recorder_fail)
+    │       └─► zone.update_failure_state(now, temp_unavail, recorder_fail, valve_unavail)
     │
     ├─► controller.evaluate(now) → ControllerAction
     │       ├─► Evaluate regular zones first

--- a/docs/fault_isolation.md
+++ b/docs/fault_isolation.md
@@ -10,12 +10,12 @@ Each zone tracks its own operational status:
 |--------|-------------|
 | `initializing` | Zone starting up; awaiting first successful temperature reading |
 | `normal` | Zone operating normally with valid temperature readings |
-| `degraded` | Temperature sensor unavailable; using last-known duty cycle |
+| `degraded` | Temperature sensor or valve entity unavailable; using last-known duty cycle |
 | `fail_safe` | No successful update for >1 hour; valve forced closed |
 
 **Initializing:** No valve actions are taken until all zones have valid readings and exit initialization. Entities remain available using restored state from storage.
 
-**Degraded:** PID continues with cached demand, zone still responds to setpoint changes.
+**Degraded:** PID continues with cached demand, zone still responds to setpoint changes. Triggered by temperature sensor unavailability, valve entity unavailability, or Recorder query failure.
 
 **Fail-safe:** Valve forced closed, zone excluded from heating. Recovery requires successful temperature reading.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,12 +321,14 @@ def mock_setup_entry() -> Generator[None]:
 @pytest.fixture
 async def mock_temp_sensor(hass: HomeAssistant) -> None:
     """
-    Set up mock temperature sensor state.
+    Set up mock temperature sensor and valve entity states.
 
     Use this fixture in tests that need the climate entity to be available.
-    Without a temperature reading, climate entities are marked unavailable.
+    Without a temperature reading and available valve entity, zones cannot
+    reach NORMAL status and climate entities are marked unavailable.
     """
     hass.states.async_set("sensor.zone1_temp", "20.5")
+    hass.states.async_set("switch.zone1_valve", "off")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/scenarios/test_coordinator_persistence.py
+++ b/tests/scenarios/test_coordinator_persistence.py
@@ -377,6 +377,7 @@ async def test_crash_recovery_preserves_valve_off_when_duty_cycle_zero(
 
     # Temperature at setpoint
     hass.states.async_set("sensor.zone1_temp", "20.5")
+    hass.states.async_set("switch.zone1_valve", "off")
 
     with patch(
         "homeassistant.helpers.storage.Store.async_load",
@@ -1006,8 +1007,9 @@ async def test_valve_actions_execute_after_initialization(
     After temperature sensors provide readings and zones transition to NORMAL,
     the controller should evaluate and execute valve actions.
     """
-    # Set up temperature sensor - zone will transition to NORMAL
+    # Set up temperature sensor and valve - zone will transition to NORMAL
     hass.states.async_set("sensor.zone1_temp", "18.0")  # Cold room
+    hass.states.async_set("switch.zone1_valve", "off")
 
     # Set up stored state with high duty cycle to ensure valve should turn on
     stored_data = {


### PR DESCRIPTION
Valve entity unavailable/unknown state now triggers zone degraded mode (and eventually fail-safe), matching the existing temp sensor behavior. Also adds a warning log when the temperature entity is not found.