### PR TITLE
Add shorter initializing timeout for faster fail-safe reporting

### DIFF
--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -98,6 +98,7 @@ class ValveState(StrEnum):
 FAILURE_NOTIFICATION_THRESHOLD = (
     3  # Create notification after this many consecutive failures
 )
+INITIALIZING_TIMEOUT = 120  # 2 minutes before fail-safe during initialization
 FAIL_SAFE_TIMEOUT = 3600  # 1 hour in seconds before activating fail-safe mode
 
 # Coordinator update intervals

--- a/docs/fault_isolation.md
+++ b/docs/fault_isolation.md
@@ -11,13 +11,13 @@ Each zone tracks its own operational status:
 | `initializing` | Zone starting up; awaiting first successful temperature reading |
 | `normal` | Zone operating normally with valid temperature readings |
 | `degraded` | Temperature sensor or valve entity unavailable; using last-known duty cycle |
-| `fail_safe` | No successful update for >1 hour; valve forced closed |
+| `fail_safe` | No successful update within timeout; valve forced closed |
 
 **Initializing:** No valve actions are taken until all zones have valid readings and exit initialization. Entities remain available using restored state from storage.
 
 **Degraded:** PID continues with cached demand, zone still responds to setpoint changes. Triggered by temperature sensor unavailability, valve entity unavailability, or Recorder query failure.
 
-**Fail-safe:** Valve forced closed, zone excluded from heating. Recovery requires successful temperature reading.
+**Fail-safe:** Valve forced closed, zone excluded from heating. During initialization (no prior successful update), fail-safe activates after 2 minutes of continuous failures to surface misconfigurations quickly. After normal operation, the timeout is 1 hour.
 
 ## Zone Isolation Guarantee
 

--- a/tests/unit/test_zone_failure.py
+++ b/tests/unit/test_zone_failure.py
@@ -1,0 +1,143 @@
+"""Unit tests for ZoneRuntime.update_failure_state timeout selection."""
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.ufh_controller.const import (
+    FAIL_SAFE_TIMEOUT,
+    INITIALIZING_TIMEOUT,
+    ZoneStatus,
+)
+from custom_components.ufh_controller.core.pid import PIDController
+from custom_components.ufh_controller.core.zone import (
+    ZoneConfig,
+    ZoneRuntime,
+    ZoneState,
+    ZoneStatusTransition,
+)
+
+
+def _make_runtime(zone_status: ZoneStatus = ZoneStatus.INITIALIZING) -> ZoneRuntime:
+    """Create a ZoneRuntime for testing."""
+    config = ZoneConfig(
+        zone_id="test_zone",
+        name="Test Zone",
+        temp_sensor="sensor.test_temp",
+        valve_switch="switch.test_valve",
+    )
+    state = ZoneState(zone_id="test_zone", zone_status=zone_status)
+    pid = PIDController(kp=50.0, ki=0.001, kd=0.0)
+    return ZoneRuntime(config=config, pid=pid, state=state)
+
+
+class TestUpdateFailureStateTimeoutSelection:
+    """Test that update_failure_state selects the correct timeout."""
+
+    def test_initializing_zone_uses_initializing_timeout(self) -> None:
+        """Zone in INITIALIZING uses the shorter initializing_timeout."""
+        runtime = _make_runtime(ZoneStatus.INITIALIZING)
+        now = datetime.now(UTC)
+
+        # First failure: sets last_successful_update
+        runtime.update_failure_state(
+            now,
+            temp_unavailable=True,
+            recorder_failure=False,
+            valve_unavailable=False,
+        )
+
+        # After initializing_timeout: should trigger fail-safe
+        later = now + timedelta(seconds=INITIALIZING_TIMEOUT + 1)
+        result = runtime.update_failure_state(
+            later,
+            temp_unavailable=True,
+            recorder_failure=False,
+            valve_unavailable=False,
+        )
+
+        assert result.transition == ZoneStatusTransition.ENTERED_FAIL_SAFE
+        assert result.timeout_used == INITIALIZING_TIMEOUT
+        assert runtime.state.zone_status == ZoneStatus.FAIL_SAFE
+
+    def test_initializing_zone_does_not_trigger_before_timeout(self) -> None:
+        """Zone in INITIALIZING does NOT trigger fail-safe before timeout."""
+        runtime = _make_runtime(ZoneStatus.INITIALIZING)
+        now = datetime.now(UTC)
+
+        # First failure: sets last_successful_update
+        runtime.update_failure_state(
+            now,
+            temp_unavailable=True,
+            recorder_failure=False,
+            valve_unavailable=False,
+        )
+
+        # Before initializing_timeout: should NOT trigger fail-safe
+        later = now + timedelta(seconds=INITIALIZING_TIMEOUT - 1)
+        result = runtime.update_failure_state(
+            later,
+            temp_unavailable=True,
+            recorder_failure=False,
+            valve_unavailable=False,
+        )
+
+        assert result.transition == ZoneStatusTransition.NONE
+        assert result.timeout_used == INITIALIZING_TIMEOUT
+        assert runtime.state.zone_status == ZoneStatus.INITIALIZING
+
+    def test_normal_zone_uses_fail_safe_timeout(self) -> None:
+        """Zone in NORMAL uses the full fail_safe_timeout."""
+        runtime = _make_runtime(ZoneStatus.NORMAL)
+        now = datetime.now(UTC)
+        runtime.state.last_successful_update = now
+
+        # After initializing_timeout but before fail_safe_timeout
+        later = now + timedelta(seconds=INITIALIZING_TIMEOUT + 1)
+        result = runtime.update_failure_state(
+            later,
+            temp_unavailable=True,
+            recorder_failure=False,
+            valve_unavailable=False,
+        )
+
+        # Should NOT be fail-safe - only 120s elapsed, need 3600s
+        assert result.transition == ZoneStatusTransition.ENTERED_DEGRADED
+        assert result.timeout_used == FAIL_SAFE_TIMEOUT
+        assert runtime.state.zone_status == ZoneStatus.DEGRADED
+
+    def test_normal_zone_triggers_fail_safe_after_full_timeout(self) -> None:
+        """Zone that was NORMAL transitions directly to FAIL_SAFE after full timeout."""
+        runtime = _make_runtime(ZoneStatus.NORMAL)
+        now = datetime.now(UTC)
+        runtime.state.last_successful_update = now
+
+        # After full fail_safe_timeout: goes directly to FAIL_SAFE
+        later = now + timedelta(seconds=FAIL_SAFE_TIMEOUT + 1)
+        result = runtime.update_failure_state(
+            later,
+            temp_unavailable=True,
+            recorder_failure=False,
+            valve_unavailable=False,
+        )
+        assert result.transition == ZoneStatusTransition.ENTERED_FAIL_SAFE
+        assert result.timeout_used == FAIL_SAFE_TIMEOUT
+        assert runtime.state.zone_status == ZoneStatus.FAIL_SAFE
+
+    def test_degraded_zone_uses_fail_safe_timeout(self) -> None:
+        """Zone in DEGRADED uses the full fail_safe_timeout."""
+        runtime = _make_runtime(ZoneStatus.DEGRADED)
+        now = datetime.now(UTC)
+        runtime.state.last_successful_update = now
+
+        # After initializing_timeout but before fail_safe_timeout
+        later = now + timedelta(seconds=INITIALIZING_TIMEOUT + 1)
+        result = runtime.update_failure_state(
+            later,
+            temp_unavailable=True,
+            recorder_failure=False,
+            valve_unavailable=False,
+        )
+
+        # Should NOT be fail-safe - DEGRADED uses the full timeout
+        assert result.transition == ZoneStatusTransition.NONE
+        assert result.timeout_used == FAIL_SAFE_TIMEOUT
+        assert runtime.state.zone_status == ZoneStatus.DEGRADED


### PR DESCRIPTION
Zones stuck in INITIALIZING (e.g. misconfigured valve entities) now enter FAIL_SAFE after 2 minutes instead of waiting the full 1-hour timeout. The timeout selection lives in update_failure_state() which returns a FailureStateResult bundling the transition and timeout used, so the coordinator logs the correct value without duplicating logic.