### PR TITLE
Remove circulation_entity configuration option

### DIFF
--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -46,7 +46,6 @@ CONF_NAME = "name"
 CONF_CONTROLLER_ID = "controller_id"
 CONF_HEAT_REQUEST_ENTITY = "heat_request_entity"
 CONF_DHW_ACTIVE_ENTITY = "dhw_active_entity"
-CONF_CIRCULATION_ENTITY = "circulation_entity"
 CONF_SUMMER_MODE_ENTITY = "summer_mode_entity"
 
 
@@ -552,7 +551,6 @@ class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_CONTROLLER_ID: controller_id,
                     CONF_HEAT_REQUEST_ENTITY: user_input.get(CONF_HEAT_REQUEST_ENTITY),
                     CONF_DHW_ACTIVE_ENTITY: user_input.get(CONF_DHW_ACTIVE_ENTITY),
-                    CONF_CIRCULATION_ENTITY: user_input.get(CONF_CIRCULATION_ENTITY),
                     CONF_SUMMER_MODE_ENTITY: user_input.get(CONF_SUMMER_MODE_ENTITY),
                 },
                 options={
@@ -571,9 +569,6 @@ class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         selector.EntitySelectorConfig(domain="switch")
                     ),
                     vol.Optional(CONF_DHW_ACTIVE_ENTITY): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="binary_sensor")
-                    ),
-                    vol.Optional(CONF_CIRCULATION_ENTITY): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="binary_sensor")
                     ),
                     vol.Optional(CONF_SUMMER_MODE_ENTITY): selector.EntitySelector(
@@ -626,7 +621,6 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
                 **self.config_entry.data,
                 CONF_HEAT_REQUEST_ENTITY: user_input.get(CONF_HEAT_REQUEST_ENTITY),
                 CONF_DHW_ACTIVE_ENTITY: user_input.get(CONF_DHW_ACTIVE_ENTITY),
-                CONF_CIRCULATION_ENTITY: user_input.get(CONF_CIRCULATION_ENTITY),
                 CONF_SUMMER_MODE_ENTITY: user_input.get(CONF_SUMMER_MODE_ENTITY),
             }
             self.hass.config_entries.async_update_entry(
@@ -656,14 +650,6 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_DHW_ACTIVE_ENTITY,
                         description={
                             "suggested_value": current_data.get(CONF_DHW_ACTIVE_ENTITY)
-                        },
-                    ): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="binary_sensor")
-                    ),
-                    vol.Optional(
-                        CONF_CIRCULATION_ENTITY,
-                        description={
-                            "suggested_value": current_data.get(CONF_CIRCULATION_ENTITY)
                         },
                     ): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="binary_sensor")

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -182,7 +182,6 @@ class UFHControllerDataUpdateCoordinator(
             name=data["name"],
             heat_request_entity=data.get("heat_request_entity"),
             dhw_active_entity=data.get("dhw_active_entity"),
-            circulation_entity=data.get("circulation_entity"),
             summer_mode_entity=data.get("summer_mode_entity"),
             timing=timing,
             zones=zones,
@@ -248,8 +247,6 @@ class UFHControllerDataUpdateCoordinator(
             entity_ids.append(summer_mode)
         if dhw_active := entry.data.get("dhw_active_entity"):
             entity_ids.append(dhw_active)
-        if circulation := entry.data.get("circulation_entity"):
-            entity_ids.append(circulation)
 
         # Zone valve switches from subentries
         entity_ids.extend(

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -53,7 +53,6 @@ class ControllerConfig:
     name: str
     heat_request_entity: str | None = None
     dhw_active_entity: str | None = None
-    circulation_entity: str | None = None
     summer_mode_entity: str | None = None
     timing: TimingParams = field(default_factory=TimingParams)
     zones: list[ZoneConfig] = field(default_factory=list)

--- a/custom_components/ufh_controller/strings.json
+++ b/custom_components/ufh_controller/strings.json
@@ -8,7 +8,6 @@
           "name": "Controller name",
           "heat_request_entity": "Heat request switch",
           "dhw_active_entity": "DHW active sensor",
-          "circulation_entity": "Circulation pump sensor",
           "summer_mode_entity": "Summer mode select"
         }
       }
@@ -31,7 +30,6 @@
         "data": {
           "heat_request_entity": "Heat request switch",
           "dhw_active_entity": "DHW active sensor",
-          "circulation_entity": "Circulation pump sensor",
           "summer_mode_entity": "Summer mode select"
         }
       },

--- a/custom_components/ufh_controller/translations/en.json
+++ b/custom_components/ufh_controller/translations/en.json
@@ -8,7 +8,6 @@
           "name": "Controller name",
           "heat_request_entity": "Heat request switch",
           "dhw_active_entity": "DHW active sensor",
-          "circulation_entity": "Circulation pump sensor",
           "summer_mode_entity": "Summer mode select"
         }
       }
@@ -31,7 +30,6 @@
         "data": {
           "heat_request_entity": "Heat request switch",
           "dhw_active_entity": "DHW active sensor",
-          "circulation_entity": "Circulation pump sensor",
           "summer_mode_entity": "Summer mode select"
         }
       },

--- a/docs/config_flow.md
+++ b/docs/config_flow.md
@@ -20,7 +20,6 @@ To control the boiler, configure either a Heat Request Switch or Summer Mode Sel
 | controller_id | string | Auto | Unique ID (auto-generated from name) |
 | heat_request_entity | entity (switch) | No | Switch to signal heat demand to boiler |
 | dhw_active_entity | entity (binary_sensor) | No | Sensor indicating DHW tank is heating |
-| circulation_entity | entity (binary_sensor) | No | Sensor indicating circulation pump is running |
 | summer_mode_entity | entity (select) | No | Select to enable/disable boiler UFH circuit |
 
 On entry setup, a **controller subentry** is automatically created to:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -428,18 +428,6 @@ A binary sensor indicating when the boiler is heating domestic hot water (DHW).
 
 **Why it matters:** Prevents new heating demands from competing with DHW heating, which typically has priority. Allowing existing valves to stay open enables continued water circulation through the thermal mass of the floor, providing some heat distribution even during DHW priority. Also enables flush circuits to capture waste heat.
 
-#### circulation_entity
-
-**Type:** Binary sensor entity
-**Required:** No
-**Config location:** ConfigEntry → `data.circulation_entity`
-
-A binary sensor indicating when the boiler's circulation pump is running.
-
-**How it works:** Currently informational; may be used in future features for detecting flow/no-flow conditions.
-
-**Example:** `binary_sensor.boiler_circulation` → Indicates water is circulating through the heating system.
-
 #### summer_mode_entity
 
 **Type:** Select entity

--- a/tests/config/test_config_flow_user.py
+++ b/tests/config/test_config_flow_user.py
@@ -62,7 +62,6 @@ async def test_user_flow_with_all_entities(
             "name": "Full Controller",
             "heat_request_entity": "switch.boiler_heat",
             "dhw_active_entity": "binary_sensor.dhw_active",
-            "circulation_entity": "binary_sensor.circulation",
             "summer_mode_entity": "select.summer_mode",
         },
     )
@@ -70,7 +69,6 @@ async def test_user_flow_with_all_entities(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"]["heat_request_entity"] == "switch.boiler_heat"
     assert result["data"]["dhw_active_entity"] == "binary_sensor.dhw_active"
-    assert result["data"]["circulation_entity"] == "binary_sensor.circulation"
     assert result["data"]["summer_mode_entity"] == "select.summer_mode"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,7 +264,6 @@ def mock_config_entry_all_entities() -> MockConfigEntry:
             "heat_request_entity": "switch.heat_request",
             "summer_mode_entity": "select.summer_mode",
             "dhw_active_entity": "binary_sensor.dhw_active",
-            "circulation_entity": "binary_sensor.circulation",
         },
         options={
             "timing": DEFAULT_TIMING,

--- a/tests/scenarios/test_coordinator_state_tracking.py
+++ b/tests/scenarios/test_coordinator_state_tracking.py
@@ -23,7 +23,6 @@ from custom_components.ufh_controller.coordinator import (
         ("binary_sensor.dhw_active", "off", "on"),
         ("switch.heat_request", "off", "on"),
         ("select.summer_mode", "winter", "summer"),
-        ("binary_sensor.circulation", "off", "on"),
         ("switch.zone1_valve", "off", "on"),
     ],
 )


### PR DESCRIPTION
## Summary
Removes the `circulation_entity` configuration option from the UFH controller integration. This entity was previously used as an informational sensor to indicate when the boiler's circulation pump was running, but was never actively used in the controller logic.

## Changes Made
- **Config Flow**: Removed `CONF_CIRCULATION_ENTITY` constant and all related form fields from both `async_step_user()` and `async_step_control_entities()` configuration steps
- **Core Controller**: Removed `circulation_entity` field from `ControllerConfig` dataclass
- **Coordinator**: Removed circulation entity from listener setup in `_async_setup_listeners()`
- **Strings & Translations**: Removed "Circulation pump sensor" label from `strings.json` and `en.json`
- **Documentation**: Removed circulation_entity section from both `config_flow.md` and `configuration.md`
- **Tests**: Updated test fixtures and assertions to remove circulation entity references

## Rationale
The circulation entity was marked as "currently informational" with no active use in the controller logic. Removing it simplifies the configuration interface and reduces unnecessary entity tracking without impacting functionality.