### PR TITLE
Fix listener cleanup on config entry unload after reload

### DIFF
--- a/custom_components/ufh_controller/__init__.py
+++ b/custom_components/ufh_controller/__init__.py
@@ -56,6 +56,9 @@ async def async_setup_entry(
 
     entry.runtime_data = UFHControllerData(coordinator=coordinator)
 
+    # Register coordinator cleanup for entry unload (handles listener cleanup)
+    entry.async_on_unload(coordinator.shutdown)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_handle_config_update))
 

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -262,8 +262,21 @@ class UFHControllerDataUpdateCoordinator(
         self._listener_unsub = async_track_state_change_event(
             self.hass, entity_ids, self._on_external_entity_change
         )
-        self.config_entry.async_on_unload(self._listener_unsub)
         LOGGER.debug("Subscribed to state changes for entities: %s", entity_ids)
+
+    @callback
+    def shutdown(self) -> None:
+        """
+        Clean up resources on config entry unload.
+
+        This method should be registered with async_on_unload() once during setup.
+        It handles cleanup of listeners that may have been set up multiple times
+        during in-place config reloads.
+        """
+        if self._listener_unsub is not None:
+            self._listener_unsub()
+            self._listener_unsub = None
+            LOGGER.debug("Unsubscribed state change listeners on shutdown")
 
     @callback
     def _on_external_entity_change(self, event: Event[EventStateChangedData]) -> None:

--- a/tests/config/test_init.py
+++ b/tests/config/test_init.py
@@ -345,3 +345,57 @@ async def test_subentry_update_event_ignores_other_subentry_types(
 
         # async_reload_config should NOT be called for unknown subentry type
         mock_reload_config.assert_not_called()
+
+
+async def test_unload_after_config_reload_no_double_unsubscribe(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """
+    Test unload after in-place config reload doesn't double-unsubscribe listeners.
+
+    This is a regression test for a crash that occurred when:
+    1. Entry is set up (listeners registered with async_on_unload)
+    2. In-place config reload (old listeners manually unsubscribed, new registered)
+    3. Entry unload tries to unsubscribe the already-unsubscribed old listeners
+
+    The error was: ValueError: list.remove(x): x not in list
+    """
+    mock_config_entry.add_to_hass(hass)
+    hass.states.async_set("sensor.zone1_temp", "20.5")
+
+    # Step 1: Setup entry (listeners registered via async_on_unload)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+
+    # Find zone subentry for parameter change
+    zone_subentry = None
+    for subentry in mock_config_entry.subentries.values():
+        if subentry.subentry_type == SUBENTRY_TYPE_ZONE:
+            zone_subentry = subentry
+            break
+    assert zone_subentry is not None
+
+    # Step 2: Trigger in-place config reload by changing parameters
+    # This calls _async_setup_listeners() again, which manually unsubscribes
+    # the old listener but the old callback is still in async_on_unload list
+    new_pid = {**DEFAULT_PID, "kp": 25.0}
+    updated_data = {**zone_subentry.data, "pid": new_pid}
+
+    hass.config_entries.async_update_subentry(
+        mock_config_entry,
+        zone_subentry,
+        data=updated_data,
+    )
+    await hass.async_block_till_done()
+
+    # Verify the config was reloaded in-place (not full reload)
+    assert coordinator.controller.get_zone_runtime("zone1").config.kp == 25.0
+
+    # Step 3: Unload should succeed without ValueError from double-unsubscribe
+    # Before the fix, this would raise:
+    # ValueError: list.remove(x): x not in list
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
## Summary
Fixes a crash that occurred when unloading a config entry after an in-place configuration reload. The issue was caused by listeners being registered multiple times with `async_on_unload()` during reloads, leading to double-unsubscribe attempts.

## Changes
- **coordinator.py**: 
  - Removed direct `async_on_unload()` registration from `_async_setup_listeners()` to prevent duplicate cleanup callbacks
  - Added new `shutdown()` method that safely handles listener cleanup with null checks and logging
  - The `shutdown()` method is now registered once during entry setup instead of multiple times during reloads

- **__init__.py**:
  - Register `coordinator.shutdown()` with `async_on_unload()` once during entry setup
  - This ensures cleanup happens exactly once, regardless of how many times listeners are reconfigured

- **tests/config/test_init.py**:
  - Added regression test `test_unload_after_config_reload_no_double_unsubscribe()` that verifies the fix
  - Test reproduces the original crash scenario: setup → in-place reload → unload

## Implementation Details
The root cause was that `_async_setup_listeners()` was called both during initial setup and during in-place config reloads. Each call registered the listener's unsubscribe callback with `async_on_unload()`, creating multiple cleanup callbacks for the same listener. When the entry was unloaded, Home Assistant would try to call all registered callbacks, causing the second call to fail since the listener was already unsubscribed.

The fix separates concerns: listener setup/teardown is handled by `_async_setup_listeners()` and `shutdown()`, while entry-level cleanup registration happens once in `async_setup_entry()`.

https://claude.ai/code/session_012m95HP7Ubon1dgVhF3jnmn