### PR TITLE
Update PID error sensor icons to use plus/minus variants

### DIFF
--- a/custom_components/ufh_controller/sensor.py
+++ b/custom_components/ufh_controller/sensor.py
@@ -206,9 +206,9 @@ class UFHPidErrorSensor(UFHZoneSensor):
         if value is None:
             return "mdi:thermometer-off"
         if value > ICON_PID_ERROR_THRESHOLD:
-            return "mdi:thermometer-chevron-up"
+            return "mdi:thermometer-plus"
         if value < -ICON_PID_ERROR_THRESHOLD:
-            return "mdi:thermometer-chevron-down"
+            return "mdi:thermometer-minus"
         return "mdi:thermometer-check"
 
 

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -179,10 +179,10 @@ async def test_zone_sensor_unavailable_during_fail_safe(
     ("error_value", "expected_icon"),
     [
         (None, "mdi:thermometer-off"),
-        (1.0, "mdi:thermometer-chevron-up"),  # Cold, needs heating
-        (ICON_PID_ERROR_THRESHOLD + 0.01, "mdi:thermometer-chevron-up"),
-        (-1.0, "mdi:thermometer-chevron-down"),  # Warm, above setpoint
-        (-ICON_PID_ERROR_THRESHOLD - 0.01, "mdi:thermometer-chevron-down"),
+        (1.0, "mdi:thermometer-plus"),  # Cold, needs heating
+        (ICON_PID_ERROR_THRESHOLD + 0.01, "mdi:thermometer-plus"),
+        (-1.0, "mdi:thermometer-minus"),  # Warm, above setpoint
+        (-ICON_PID_ERROR_THRESHOLD - 0.01, "mdi:thermometer-minus"),
         (0.0, "mdi:thermometer-check"),  # At setpoint
         (ICON_PID_ERROR_THRESHOLD - 0.01, "mdi:thermometer-check"),
         (-ICON_PID_ERROR_THRESHOLD + 0.01, "mdi:thermometer-check"),


### PR DESCRIPTION
## Summary
Updated the Material Design Icons used for PID error status indicators in the UFH controller sensor component to use more semantically appropriate icon variants.

## Changes
- Replaced `mdi:thermometer-chevron-up` with `mdi:thermometer-plus` for positive PID errors (temperature below setpoint, heating needed)
- Replaced `mdi:thermometer-chevron-down` with `mdi:thermometer-minus` for negative PID errors (temperature above setpoint, cooling needed)
- Updated corresponding test cases to reflect the new icon names

## Details
The plus/minus icon variants better represent the directional adjustment needed (increase/decrease temperature) compared to the chevron variants. This improves the visual clarity and semantic meaning of the status indicators for users monitoring zone temperatures.

https://claude.ai/code/session_01KQQ12PY5RhizL2NCrS4jFM