### PR TITLE
Rename PIDState fields for consistency

### DIFF
--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -391,9 +391,9 @@ class UFHControllerDataUpdateCoordinator(
         if runtime.pid.state is None and "duty_cycle" in zone_state:
             pid_state = PIDState(
                 error=zone_state.get("pid_error", 0.0),
-                p_term=zone_state.get("pid_proportional", 0.0),
-                i_term=zone_state.get("pid_integral", 0.0),
-                d_term=zone_state.get("pid_derivative", 0.0),
+                proportional=zone_state.get("pid_proportional", 0.0),
+                integral=zone_state.get("pid_integral", 0.0),
+                derivative=zone_state.get("pid_derivative", 0.0),
                 duty_cycle=zone_state.get("duty_cycle", 0.0),
             )
             runtime.pid.set_state(pid_state)
@@ -1133,9 +1133,9 @@ class UFHControllerDataUpdateCoordinator(
                 "setpoint": state.setpoint,
                 "duty_cycle": pid_state.duty_cycle if pid_state else None,
                 "pid_error": pid_state.error if pid_state else None,
-                "pid_proportional": pid_state.p_term if pid_state else None,
-                "pid_integral": pid_state.i_term if pid_state else None,
-                "pid_derivative": pid_state.d_term if pid_state else None,
+                "pid_proportional": pid_state.proportional if pid_state else None,
+                "pid_integral": pid_state.integral if pid_state else None,
+                "pid_derivative": pid_state.derivative if pid_state else None,
                 "valve_state": state.valve_state.value,
                 "enabled": state.enabled,
                 "blocked": blocked,

--- a/custom_components/ufh_controller/core/pid.py
+++ b/custom_components/ufh_controller/core/pid.py
@@ -14,14 +14,14 @@ class PIDState:
     Complete state of the PID controller.
 
     This frozen dataclass contains both the output values from the last
-    update and the internal accumulator state (i_term serves as the
+    update and the internal accumulator state (integral serves as the
     integral accumulator, error serves as last_error for derivative).
     """
 
     error: float
-    p_term: float
-    i_term: float
-    d_term: float
+    proportional: float
+    integral: float
+    derivative: float
     duty_cycle: float
 
 
@@ -75,27 +75,26 @@ class PIDController:
         error = setpoint - current
 
         # Proportional term
-        p_term = self.kp * error
+        proportional = self.kp * error
 
         # Integral term with anti-windup
-        # Use previous i_term as the integral accumulator
-        prev_integral = self._state.i_term if self._state else 0.0
+        # Use previous integral as the integral accumulator
+        prev_integral = self._state.integral if self._state else 0.0
         integral = prev_integral + self.ki * error * dt
         integral = max(self.integral_min, min(self.integral_max, integral))
-        i_term = integral
 
         # Derivative term - use previous error from state
         last_error = self._state.error if self._state else 0.0
-        d_term = self.kd * (error - last_error) / dt
+        derivative = self.kd * (error - last_error) / dt
 
         # Output clamped to 0-100%
-        duty_cycle = max(0.0, min(100.0, p_term + i_term + d_term))
+        duty_cycle = max(0.0, min(100.0, proportional + integral + derivative))
 
         self._state = PIDState(
             error=error,
-            p_term=p_term,
-            i_term=i_term,
-            d_term=d_term,
+            proportional=proportional,
+            integral=integral,
+            derivative=derivative,
             duty_cycle=duty_cycle,
         )
         return self._state

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,13 +152,13 @@ PID parameters control the temperature regulation algorithm for each zone. These
 
 The proportional gain determines the immediate response to temperature error. Higher values create stronger responses to temperature deviations.
 
-**How it works:** The proportional term is calculated as `p_term = kp × error`, where `error = setpoint - current_temperature`. If the room is 2°C below setpoint and `kp=50`, then `p_term = 50 × 2 = 100%` duty cycle (clamped to 100%).
+**How it works:** The proportional term is calculated as `proportional = kp × error`, where `error = setpoint - current_temperature`. If the room is 2°C below setpoint and `kp=50`, then `proportional = 50 × 2 = 100%` duty cycle (clamped to 100%).
 
 **Examples:**
-- Room at 20°C, setpoint 21°C, `kp=50`: `p_term = 50 × 1 = 50%` duty cycle.
-- Room at 19°C, setpoint 21°C, `kp=50`: `p_term = 50 × 2 = 100%` duty cycle.
-- Room at 20.5°C, setpoint 21°C, `kp=50`: `p_term = 50 × 0.5 = 25%` duty cycle.
-- Same conditions with `kp=100`: `p_term = 100 × 0.5 = 50%` duty cycle (more aggressive).
+- Room at 20°C, setpoint 21°C, `kp=50`: `proportional = 50 × 1 = 50%` duty cycle.
+- Room at 19°C, setpoint 21°C, `kp=50`: `proportional = 50 × 2 = 100%` duty cycle.
+- Room at 20.5°C, setpoint 21°C, `kp=50`: `proportional = 50 × 0.5 = 25%` duty cycle.
+- Same conditions with `kp=100`: `proportional = 100 × 0.5 = 50%` duty cycle (more aggressive).
 
 **Why it matters:** Too low results in slow temperature recovery. Too high causes oscillation around the setpoint. For hydronic heating with slow thermal response, 50.0 is a good starting point.
 
@@ -225,13 +225,13 @@ The time constant for the Exponential Moving Average (EMA) filter applied to tem
 
 The derivative gain responds to the rate of change of temperature error, providing damping against oscillations.
 
-**How it works:** The derivative term is calculated as `d_term = kd × (error - last_error) / dt`. If temperature is changing rapidly, the derivative term adjusts the output to slow the approach to setpoint.
+**How it works:** The derivative term is calculated as `derivative = kd × (error - last_error) / dt`. If temperature is changing rapidly, the derivative term adjusts the output to slow the approach to setpoint.
 
 **Examples:**
 - Error changed from 1.0°C to 0.5°C in 60 seconds, `kd=10`:
-  - `d_term = 10 × (0.5 - 1.0) / 60 = -0.083%` (negative because error is decreasing)
+  - `derivative = 10 × (0.5 - 1.0) / 60 = -0.083%` (negative because error is decreasing)
 - Error changed from 0.5°C to 2.0°C in 60 seconds, `kd=10`:
-  - `d_term = 10 × (2.0 - 0.5) / 60 = 0.25%` (positive because error is increasing)
+  - `derivative = 10 × (2.0 - 0.5) / 60 = 0.25%` (positive because error is increasing)
 
 **Why it matters:** Derivative control can reduce overshoot and oscillation in fast-responding systems. However, hydronic heating systems are very slow and derivative control often adds noise rather than improvement. The default `kd=0.0` disables derivative control, which is appropriate for most UFH systems.
 

--- a/tests/config/test_init.py
+++ b/tests/config/test_init.py
@@ -93,9 +93,9 @@ async def test_config_update_parameter_change_in_place(
     zone_runtime.pid.set_state(
         PIDState(
             error=-1.5,
-            p_term=15.0,
-            i_term=10.0,
-            d_term=5.0,
+            proportional=15.0,
+            integral=10.0,
+            derivative=5.0,
             duty_cycle=30.0,
         )
     )

--- a/tests/integration/test_sensor.py
+++ b/tests/integration/test_sensor.py
@@ -211,9 +211,9 @@ async def test_pid_error_sensor_icon(
     zone1.pid._state = (
         PIDState(
             error=error_value if error_value is not None else 0.0,
-            p_term=old_state.p_term if old_state else 0.0,
-            i_term=old_state.i_term if old_state else 0.0,
-            d_term=old_state.d_term if old_state else 0.0,
+            proportional=old_state.proportional if old_state else 0.0,
+            integral=old_state.integral if old_state else 0.0,
+            derivative=old_state.derivative if old_state else 0.0,
             duty_cycle=old_state.duty_cycle if old_state else 0.0,
         )
         if error_value is not None
@@ -263,9 +263,9 @@ async def test_duty_cycle_sensor_icon(
     zone1.pid._state = (
         PIDState(
             error=old_state.error if old_state else 0.0,
-            p_term=old_state.p_term if old_state else 0.0,
-            i_term=old_state.i_term if old_state else 0.0,
-            d_term=old_state.d_term if old_state else 0.0,
+            proportional=old_state.proportional if old_state else 0.0,
+            integral=old_state.integral if old_state else 0.0,
+            derivative=old_state.derivative if old_state else 0.0,
             duty_cycle=duty_cycle_value if duty_cycle_value is not None else 0.0,
         )
         if duty_cycle_value is not None

--- a/tests/scenarios/test_coordinator_persistence.py
+++ b/tests/scenarios/test_coordinator_persistence.py
@@ -84,9 +84,9 @@ async def test_coordinator_loads_stored_state(
     assert runtime is not None
     assert runtime.pid.state is not None
     assert runtime.pid.state.error == 2.0
-    assert runtime.pid.state.p_term == 30.0
-    assert runtime.pid.state.i_term == 45.5
-    assert runtime.pid.state.d_term == 1.5
+    assert runtime.pid.state.proportional == 30.0
+    assert runtime.pid.state.integral == 45.5
+    assert runtime.pid.state.derivative == 1.5
     assert runtime.pid.state.duty_cycle == 55.0
 
     # Check EMA temperature was restored (value between stored and raw)
@@ -123,7 +123,9 @@ async def test_coordinator_save_state_format(
 
     # Set PID state that should be persisted
     runtime.pid.set_state(
-        PIDState(error=1.5, p_term=25.0, i_term=75.0, d_term=0.8, duty_cycle=65.0)
+        PIDState(
+            error=1.5, proportional=25.0, integral=75.0, derivative=0.8, duty_cycle=65.0
+        )
     )
 
     # Set EMA-filtered temperature that should be persisted
@@ -255,9 +257,9 @@ async def test_coordinator_caps_dt_after_long_downtime(
     # With capped dt (2 * 60 = 120 seconds), max addition is 2.0 * 0.001 * 120 = 0.24
 
     # Verify integral hasn't exploded (should be close to restored value)
-    # Restored i_term was 5.0, max addition with capped dt is ~0.24
+    # Restored integral was 5.0, max addition with capped dt is ~0.24
     assert runtime.pid.state is not None
-    assert runtime.pid.state.i_term < 10.0  # Would be ~177 if uncapped
+    assert runtime.pid.state.integral < 10.0  # Would be ~177 if uncapped
 
 
 async def test_coordinator_no_stored_state(
@@ -339,7 +341,7 @@ async def test_crash_recovery_mid_update_valve_remains_safe(
     # (some increase expected due to PID update with positive error)
     # The key point is that the stored integral was successfully restored
     # and used as the starting point for continued integration
-    assert runtime.pid.state.i_term >= 50.0  # Started from stored value
+    assert runtime.pid.state.integral >= 50.0  # Started from stored value
 
     # The system should recalculate and determine valve action
     # Since temperature (19°C) is below setpoint (22°C) and integral is positive,
@@ -451,14 +453,14 @@ async def test_crash_recovery_no_integral_windup_during_disabled_period(
     assert runtime.state.enabled is False
 
     # Record integral before update
-    integral_before = runtime.pid.state.i_term
+    integral_before = runtime.pid.state.integral
 
     # Trigger multiple updates
     for _ in range(3):
         await coordinator.async_refresh()
 
     # Integral should NOT have increased (PID paused for disabled zones)
-    assert runtime.pid.state.i_term == integral_before
+    assert runtime.pid.state.integral == integral_before
 
 
 async def test_crash_recovery_no_integral_windup_with_window_open(
@@ -535,14 +537,14 @@ async def test_crash_recovery_no_integral_windup_with_window_open(
     assert runtime is not None
 
     # Record integral before update
-    integral_before = runtime.pid.state.i_term
+    integral_before = runtime.pid.state.integral
 
     # Trigger multiple updates
     for _ in range(3):
         await coordinator.async_refresh()
 
     # Integral should NOT have increased (PID paused when window open)
-    assert runtime.pid.state.i_term == integral_before
+    assert runtime.pid.state.integral == integral_before
 
     # Clean up
     await hass.config_entries.async_unload(config_entry.entry_id)
@@ -609,7 +611,7 @@ async def test_crash_recovery_state_consistency_after_multiple_restarts(
         await coordinator.async_refresh()
 
     # Capture state after first "session"
-    integral_session1 = runtime.pid.state.i_term
+    integral_session1 = runtime.pid.state.integral
     setpoint_session1 = runtime.state.setpoint
     pid_state = runtime.pid.state
 
@@ -622,9 +624,9 @@ async def test_crash_recovery_state_consistency_after_multiple_restarts(
         "zones": {
             "zone1": {
                 "pid_error": pid_state.error,
-                "pid_proportional": pid_state.p_term,
-                "pid_integral": pid_state.i_term,
-                "pid_derivative": pid_state.d_term,
+                "pid_proportional": pid_state.proportional,
+                "pid_integral": pid_state.integral,
+                "pid_derivative": pid_state.derivative,
                 "duty_cycle": pid_state.duty_cycle,
                 "setpoint": setpoint_session1,
                 "enabled": runtime.state.enabled,
@@ -651,7 +653,7 @@ async def test_crash_recovery_state_consistency_after_multiple_restarts(
     # Verify state was restored correctly
     # After the second boot, the integral should be >= the saved value
     # (it may have increased slightly during the first refresh)
-    assert runtime.pid.state.i_term >= integral_session1
+    assert runtime.pid.state.integral >= integral_session1
     assert runtime.state.setpoint == setpoint_session1
 
     # Cleanup
@@ -724,7 +726,7 @@ async def test_crash_recovery_valve_action_sequence_integrity(
 
     # Verify the saved integral matches the current state
     # (proving state was saved AFTER the full update completed)
-    assert last_saved["zones"]["zone1"]["pid_integral"] == runtime.pid.state.i_term
+    assert last_saved["zones"]["zone1"]["pid_integral"] == runtime.pid.state.integral
 
 
 async def test_crash_recovery_mode_preserved_across_restart(
@@ -845,7 +847,7 @@ async def test_crash_recovery_partial_zone_state_restoration(
 
     # Integral should be restored and then possibly updated by first refresh
     # The key point is it started from the stored value (35.0)
-    assert runtime.pid.state.i_term >= 35.0
+    assert runtime.pid.state.integral >= 35.0
 
     # setpoint should be the default from config
     assert runtime.state.setpoint == 21.0  # DEFAULT_SETPOINT["default"]
@@ -1140,7 +1142,7 @@ async def test_crash_recovery_stale_zone_in_stored_state(
     # zone1 should be restored correctly
     # (integral may have increased after first refresh)
     runtime = coordinator.controller.get_zone_runtime("zone1")
-    assert runtime.pid.state.i_term >= 20.0  # Started from stored value
+    assert runtime.pid.state.integral >= 20.0  # Started from stored value
 
     # zone_deleted should not exist
     assert "zone_deleted" not in coordinator.controller.zone_ids
@@ -1434,7 +1436,7 @@ async def test_v1_storage_migration_on_load(
         "last_update_success_time": "2025-06-15T12:30:00+00:00",
         "zones": {
             "zone1": {
-                # V1 PID keys (error, p_term, etc.)
+                # V1 PID storage keys (error, p_term, etc.)
                 "error": 2.0,
                 "p_term": 30.0,
                 "i_term": 45.5,
@@ -1476,9 +1478,9 @@ async def test_v1_storage_migration_on_load(
     assert runtime is not None
     assert runtime.pid.state is not None
     assert runtime.pid.state.error == 2.0
-    assert runtime.pid.state.p_term == 30.0
-    assert runtime.pid.state.i_term == 45.5
-    assert runtime.pid.state.d_term == 1.5
+    assert runtime.pid.state.proportional == 30.0
+    assert runtime.pid.state.integral == 45.5
+    assert runtime.pid.state.derivative == 1.5
     assert runtime.pid.state.duty_cycle == 55.0
 
     # Check EMA temperature was restored (V1 "temperature" -> V2 "current")

--- a/tests/scenarios/test_zone_initial_state.py
+++ b/tests/scenarios/test_zone_initial_state.py
@@ -86,14 +86,14 @@ class TestControllerZoneInitialization:
         assert isinstance(runtime.pid.state.error, float), (
             "error should be a float after update"
         )
-        assert isinstance(runtime.pid.state.p_term, float), (
-            "p_term should be a float after update"
+        assert isinstance(runtime.pid.state.proportional, float), (
+            "proportional should be a float after update"
         )
-        assert isinstance(runtime.pid.state.i_term, float), (
-            "i_term should be a float after update"
+        assert isinstance(runtime.pid.state.integral, float), (
+            "integral should be a float after update"
         )
-        assert isinstance(runtime.pid.state.d_term, float), (
-            "d_term should be a float after update"
+        assert isinstance(runtime.pid.state.derivative, float), (
+            "derivative should be a float after update"
         )
         assert isinstance(runtime.pid.state.duty_cycle, float), (
             "duty_cycle should be a float after update"

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -232,7 +232,7 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
 
         # Switch to all_off mode
         controller.mode = OperationMode.ALL_OFF
@@ -242,7 +242,7 @@ class TestPIDIntegrationPause:
 
         # Integral should remain unchanged (paused)
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term == initial_integral
+        assert runtime.pid.state.integral == initial_integral
 
     def test_pid_paused_in_flush_mode(self, basic_config: ControllerConfig) -> None:
         """Test PID integration is paused when mode is flush."""
@@ -253,7 +253,7 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
 
         # Switch to flush mode
         controller.mode = OperationMode.FLUSH
@@ -261,7 +261,7 @@ class TestPIDIntegrationPause:
         # PID update should NOT accumulate integral
         setup_zone_pid(controller, "living_room", 19.0, 60.0)
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term == initial_integral
+        assert runtime.pid.state.integral == initial_integral
 
     def test_pid_paused_in_all_on_mode(self, basic_config: ControllerConfig) -> None:
         """Test PID integration is paused when mode is all_on."""
@@ -271,12 +271,12 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
 
         controller.mode = OperationMode.ALL_ON
         setup_zone_pid(controller, "living_room", 19.0, 60.0)
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term == initial_integral
+        assert runtime.pid.state.integral == initial_integral
 
     def test_pid_paused_in_off_mode(self, basic_config: ControllerConfig) -> None:
         """Test PID integration is paused when mode is off."""
@@ -286,12 +286,12 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
 
         controller.mode = OperationMode.OFF
         setup_zone_pid(controller, "living_room", 19.0, 60.0)
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term == initial_integral
+        assert runtime.pid.state.integral == initial_integral
 
     def test_pid_paused_in_cycle_mode(self, basic_config: ControllerConfig) -> None:
         """Test PID integration is paused when mode is cycle."""
@@ -301,12 +301,12 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
 
         controller.mode = OperationMode.CYCLE
         setup_zone_pid(controller, "living_room", 19.0, 60.0)
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term == initial_integral
+        assert runtime.pid.state.integral == initial_integral
 
     def test_pid_paused_when_zone_disabled(
         self, basic_config: ControllerConfig
@@ -319,7 +319,7 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
 
         # Disable the zone
         controller.set_zone_enabled("living_room", enabled=False)
@@ -327,7 +327,7 @@ class TestPIDIntegrationPause:
         # PID update should NOT accumulate integral
         setup_zone_pid(controller, "living_room", 19.0, 60.0)
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term == initial_integral
+        assert runtime.pid.state.integral == initial_integral
 
     def test_pid_paused_when_window_recently_open(
         self, basic_config: ControllerConfig
@@ -340,7 +340,7 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
 
         # Simulate window was recently open (within blocking period)
         runtime.state.window_recently_open = True
@@ -348,7 +348,7 @@ class TestPIDIntegrationPause:
         # PID update should NOT accumulate integral
         setup_zone_pid(controller, "living_room", 19.0, 60.0)
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term == initial_integral
+        assert runtime.pid.state.integral == initial_integral
 
     def test_pid_not_paused_when_window_not_recently_open(
         self, basic_config: ControllerConfig
@@ -361,7 +361,7 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
 
         # No recent window activity
         runtime.state.window_recently_open = False
@@ -369,7 +369,7 @@ class TestPIDIntegrationPause:
         # PID update SHOULD accumulate integral
         setup_zone_pid(controller, "living_room", 19.0, 60.0)
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term > initial_integral
+        assert runtime.pid.state.integral > initial_integral
 
     def test_pid_runs_normally_in_heat_mode(
         self, basic_config: ControllerConfig
@@ -383,12 +383,12 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
 
         # Second update should accumulate integral
         setup_zone_pid(controller, "living_room", 20.0, 60.0)
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term > initial_integral
+        assert runtime.pid.state.integral > initial_integral
 
     def test_pid_paused_maintains_duty_cycle(
         self, basic_config: ControllerConfig
@@ -448,20 +448,20 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        integral_after_first = runtime.pid.state.i_term
+        integral_after_first = runtime.pid.state.integral
 
         # Pause by switching mode
         controller.mode = OperationMode.ALL_OFF
         setup_zone_pid(controller, "living_room", 19.0, 60.0)
         assert runtime.pid.state is not None
-        integral_while_paused = runtime.pid.state.i_term
+        integral_while_paused = runtime.pid.state.integral
         assert integral_while_paused == integral_after_first
 
         # Resume by switching back to heat
         controller.mode = OperationMode.HEAT
         setup_zone_pid(controller, "living_room", 19.0, 60.0)
         assert runtime.pid.state is not None
-        integral_after_resume = runtime.pid.state.i_term
+        integral_after_resume = runtime.pid.state.integral
 
         # Integral should have increased after resuming
         assert integral_after_resume > integral_while_paused
@@ -477,7 +477,7 @@ class TestPIDIntegrationPause:
         runtime = controller.get_zone_runtime("living_room")
         assert runtime is not None
         assert runtime.pid.state is not None
-        initial_integral = runtime.pid.state.i_term
+        initial_integral = runtime.pid.state.integral
         initial_duty_cycle = runtime.pid.state.duty_cycle
 
         # Update with None temperature
@@ -485,7 +485,7 @@ class TestPIDIntegrationPause:
 
         # Integral should be unchanged, duty cycle maintained
         assert runtime.pid.state is not None
-        assert runtime.pid.state.i_term == initial_integral
+        assert runtime.pid.state.integral == initial_integral
         assert runtime.pid.state.duty_cycle == initial_duty_cycle
 
 

--- a/tests/unit/test_pid.py
+++ b/tests/unit/test_pid.py
@@ -17,7 +17,7 @@ class TestPIDController:
         result = pid.update(setpoint=22.0, current=20.0, dt=60.0)
         assert result is not None
         assert result.duty_cycle == 100.0  # 50 * 2 = 100, clamped
-        assert result.p_term == 100.0
+        assert result.proportional == 100.0
 
     def test_proportional_small_error(self) -> None:
         """Smaller error gives proportional output without clamping."""
@@ -25,7 +25,7 @@ class TestPIDController:
         result = pid.update(setpoint=21.0, current=20.0, dt=60.0)
         assert result is not None
         assert result.duty_cycle == 50.0  # 50 * 1 = 50
-        assert result.p_term == 50.0
+        assert result.proportional == 50.0
 
     def test_proportional_negative_error_clamped(self) -> None:
         """Negative error (setpoint < current) gives 0 (clamped)."""
@@ -33,7 +33,7 @@ class TestPIDController:
         result = pid.update(setpoint=20.0, current=22.0, dt=60.0)
         assert result is not None
         assert result.duty_cycle == 0.0  # 50 * -2 = -100, clamped to 0
-        assert result.p_term == -100.0
+        assert result.proportional == -100.0
 
     def test_integral_accumulation(self) -> None:
         """Test that integral term accumulates with dt multiplier."""
@@ -43,14 +43,14 @@ class TestPIDController:
         result1 = pid.update(setpoint=21.0, current=20.0, dt=60.0)
         assert pid.state is not None
         assert result1 is not None
-        assert pid.state.i_term == 60.0
+        assert pid.state.integral == 60.0
         assert result1.duty_cycle == pytest.approx(60.0)
-        assert result1.i_term == pytest.approx(60.0)
+        assert result1.integral == pytest.approx(60.0)
 
         # Second update: integral = 60 + 60 = 120%
         result2 = pid.update(setpoint=21.0, current=20.0, dt=60.0)
         assert result2 is not None
-        assert pid.state.i_term == 120.0
+        assert pid.state.integral == 120.0
         assert result2.duty_cycle == pytest.approx(100.0)  # Clamped to 100%
 
     def test_integral_anti_windup(self) -> None:
@@ -61,12 +61,12 @@ class TestPIDController:
         result = pid.update(setpoint=30.0, current=20.0, dt=60.0)
         assert pid.state is not None
         assert result is not None
-        assert pid.state.i_term == 50.0  # Clamped at max
+        assert pid.state.integral == 50.0  # Clamped at max
         assert result.duty_cycle == pytest.approx(50.0)
 
         # Further updates should not increase integral beyond max
         pid.update(setpoint=30.0, current=20.0, dt=60.0)
-        assert pid.state.i_term == 50.0
+        assert pid.state.integral == 50.0
 
     def test_integral_anti_windup_negative(self) -> None:
         """Test that integral is clamped at minimum too."""
@@ -77,7 +77,7 @@ class TestPIDController:
         # Negative error should drive integral down: 1.0 * -2 * 30 = -60, clamped to -50
         pid.update(setpoint=18.0, current=20.0, dt=30.0)
         assert pid.state is not None
-        assert pid.state.i_term == -50.0
+        assert pid.state.integral == -50.0
 
     def test_output_clamped_at_zero(self) -> None:
         """Test that output is clamped at 0%."""
@@ -104,21 +104,21 @@ class TestPIDController:
         assert pid.state is not None
         assert result1 is not None
         assert pid.state.error == 1.0  # error is stored for next derivative calc
-        # d_term = 10 * (1 - 0) / 60 = 0.167
-        assert result1.d_term == pytest.approx(10.0 / 60.0, rel=0.01)
+        # derivative = 10 * (1 - 0) / 60 = 0.167
+        assert result1.derivative == pytest.approx(10.0 / 60.0, rel=0.01)
         assert result1.duty_cycle == pytest.approx(10.0 / 60.0, rel=0.01)
 
         # Second update with same error - derivative should be 0
         result2 = pid.update(setpoint=21.0, current=20.0, dt=60.0)
         assert result2 is not None
-        assert result2.d_term == pytest.approx(0.0)
+        assert result2.derivative == pytest.approx(0.0)
         assert result2.duty_cycle == pytest.approx(0.0)
 
         # Third update with increasing error
         result3 = pid.update(setpoint=22.0, current=20.0, dt=60.0)
         assert result3 is not None
-        # d_term = 10 * (2 - 1) / 60 = 0.167
-        assert result3.d_term == pytest.approx(10.0 / 60.0, rel=0.01)
+        # derivative = 10 * (2 - 1) / 60 = 0.167
+        assert result3.derivative == pytest.approx(10.0 / 60.0, rel=0.01)
         assert result3.duty_cycle == pytest.approx(10.0 / 60.0, rel=0.01)
 
     def test_set_state(self) -> None:
@@ -127,11 +127,15 @@ class TestPIDController:
 
         # Set full state directly
         state = PIDState(
-            error=2.0, p_term=100.0, i_term=50.0, d_term=0.0, duty_cycle=50.0
+            error=2.0,
+            proportional=100.0,
+            integral=50.0,
+            derivative=0.0,
+            duty_cycle=50.0,
         )
         pid.set_state(state)
         assert pid.state is not None
-        assert pid.state.i_term == 50.0
+        assert pid.state.integral == 50.0
         assert pid.state.error == 2.0
         assert pid.state.duty_cycle == 50.0
 
@@ -150,13 +154,13 @@ class TestPIDController:
         # Accumulate some integral
         pid.update(setpoint=21.0, current=20.0, dt=60.0)
         assert pid.state is not None
-        assert pid.state.i_term == 60.0
+        assert pid.state.integral == 60.0
 
         # Zero dt should NOT reset the accumulated integral
         state_before = pid.state
         result = pid.update(setpoint=21.0, current=20.0, dt=0.0)
         assert result == state_before
-        assert pid.state.i_term == 60.0  # Integral preserved
+        assert pid.state.integral == 60.0  # Integral preserved
 
     def test_negative_dt_no_prior_state_returns_none(self) -> None:
         """Test that negative dt with no prior state returns None."""
@@ -178,7 +182,7 @@ class TestPIDController:
         # Negative dt should NOT reset the accumulated integral
         result = pid.update(setpoint=21.0, current=20.0, dt=-60.0)
         assert result == state_before
-        assert pid.state.i_term == 60.0  # Integral preserved
+        assert pid.state.integral == 60.0  # Integral preserved
 
     def test_default_values(self) -> None:
         """Test default PID parameters match spec."""
@@ -215,9 +219,9 @@ class TestPIDController:
         # I = ki * error * dt = 0.1 * 2 * 60 = 12% (stored in % units)
         # D = 1 * (2 - 0) / 60 = 0.033
         assert result.error == 2.0
-        assert result.p_term == 20.0
-        assert result.i_term == pytest.approx(12.0)
-        assert result.d_term == pytest.approx(1.0 * 2.0 / 60.0)
+        assert result.proportional == 20.0
+        assert result.integral == pytest.approx(12.0)
+        assert result.derivative == pytest.approx(1.0 * 2.0 / 60.0)
         expected = 20.0 + 12.0 + (1.0 * 2.0 / 60.0)
         assert result.duty_cycle == pytest.approx(expected, rel=0.01)
 
@@ -234,22 +238,22 @@ class TestPIDController:
         pid.update(setpoint=22.0, current=20.0, dt=60.0)
         pid.update(setpoint=22.0, current=20.0, dt=60.0)
         assert pid.state is not None
-        assert pid.state.i_term == pytest.approx(2.4)  # 1.2% + 1.2% = 2.4%
+        assert pid.state.integral == pytest.approx(2.4)  # 1.2% + 1.2% = 2.4%
 
         # Store the integral before ki change
-        integral_before = pid.state.i_term
+        integral_before = pid.state.integral
 
         # Now change ki - this should NOT affect the stored integral
         pid.ki = 0.02
 
         # Integral should remain unchanged
-        assert pid.state.i_term == integral_before
+        assert pid.state.integral == integral_before
 
         # Next update uses new ki: adds ki * error * dt = 0.02 * 2 * 60 = 2.4%
         result = pid.update(setpoint=22.0, current=20.0, dt=60.0)
         assert result is not None
-        assert pid.state.i_term == pytest.approx(4.8)  # 2.4% + 2.4% = 4.8%
-        assert result.duty_cycle == pytest.approx(4.8)  # i_term = integral = 4.8%
+        assert pid.state.integral == pytest.approx(4.8)  # 2.4% + 2.4% = 4.8%
+        assert result.duty_cycle == pytest.approx(4.8)  # integral = 4.8%
 
 
 class TestPIDState:
@@ -258,7 +262,7 @@ class TestPIDState:
     def test_state_is_frozen(self) -> None:
         """Test that PIDState is immutable (frozen)."""
         state = PIDState(
-            error=1.0, p_term=50.0, i_term=10.0, d_term=0.0, duty_cycle=60.0
+            error=1.0, proportional=50.0, integral=10.0, derivative=0.0, duty_cycle=60.0
         )
 
         with pytest.raises(AttributeError):
@@ -267,20 +271,24 @@ class TestPIDState:
     def test_state_fields(self) -> None:
         """Test PIDState with all fields."""
         state = PIDState(
-            error=2.0, p_term=100.0, i_term=30.0, d_term=0.5, duty_cycle=75.0
+            error=2.0,
+            proportional=100.0,
+            integral=30.0,
+            derivative=0.5,
+            duty_cycle=75.0,
         )
         assert state.error == 2.0
-        assert state.p_term == 100.0
-        assert state.i_term == 30.0
-        assert state.d_term == 0.5
+        assert state.proportional == 100.0
+        assert state.integral == 30.0
+        assert state.derivative == 0.5
         assert state.duty_cycle == 75.0
 
     def test_state_equality(self) -> None:
         """Test PIDState equality comparison."""
         state1 = PIDState(
-            error=1.0, p_term=50.0, i_term=10.0, d_term=0.0, duty_cycle=60.0
+            error=1.0, proportional=50.0, integral=10.0, derivative=0.0, duty_cycle=60.0
         )
         state2 = PIDState(
-            error=1.0, p_term=50.0, i_term=10.0, d_term=0.0, duty_cycle=60.0
+            error=1.0, proportional=50.0, integral=10.0, derivative=0.0, duty_cycle=60.0
         )
         assert state1 == state2


### PR DESCRIPTION
## Summary

- Rename `PIDState` dataclass fields from abbreviated names (`p_term`, `i_term`, `d_term`) to full descriptive names (`proportional`, `integral`, `derivative`), matching the naming convention used by all other state/config classes in the codebase
- Update all access sites across production code, tests, and documentation
- Leave storage keys (`pid_proportional`, `pid_integral`, `pid_derivative`), sensor entity keys, and V1 migration string keys unchanged

## Test plan

- [x] All 521 tests pass
- [x] Ruff format and lint pass
- [x] ty type check passes
- [x] 100% diff coverage confirmed
- [x] CI workflows pass (checks, lint, validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)