### PR TITLE
Fix flaky test due to EMA floating-point precision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,12 @@ def test_duty_cycle_edge_case():
     assert calculate_duty_cycle(edge_case) == expected
 ```
 
+### 5. Floating-Point Equality in Tests
+Use `pytest.approx()` for asserting float values that have passed through
+any computation (EMA, PID, division, interpolation). Direct assign-and-read
+without computation can use `==`. Dictionary comparisons with nested floats
+are especially dangerous — assert float fields individually with `approx()`.
+
 ## CI Workflows
 
 The CI runs three workflow files on PRs:

--- a/tests/scenarios/test_coordinator_persistence.py
+++ b/tests/scenarios/test_coordinator_persistence.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -162,20 +163,20 @@ async def test_coordinator_save_state_format(
     assert "last_update_success_time" in saved_data
 
     # Verify full PID state is saved
-    assert saved_data["zones"]["zone1"]["pid_error"] == 1.5
-    assert saved_data["zones"]["zone1"]["pid_proportional"] == 25.0
-    assert saved_data["zones"]["zone1"]["pid_integral"] == 75.0
-    assert saved_data["zones"]["zone1"]["pid_derivative"] == 0.8
-    assert saved_data["zones"]["zone1"]["duty_cycle"] == 65.0
+    assert saved_data["zones"]["zone1"]["pid_error"] == pytest.approx(1.5)
+    assert saved_data["zones"]["zone1"]["pid_proportional"] == pytest.approx(25.0)
+    assert saved_data["zones"]["zone1"]["pid_integral"] == pytest.approx(75.0)
+    assert saved_data["zones"]["zone1"]["pid_derivative"] == pytest.approx(0.8)
+    assert saved_data["zones"]["zone1"]["duty_cycle"] == pytest.approx(65.0)
 
     # Verify EMA temperature is saved (V2 uses 'current' key)
-    assert saved_data["zones"]["zone1"]["current"] == 21.5
+    assert saved_data["zones"]["zone1"]["current"] == pytest.approx(21.5)
     # Verify display temperature is saved
-    assert saved_data["zones"]["zone1"]["display_temp"] == 21.5
+    assert saved_data["zones"]["zone1"]["display_temp"] == pytest.approx(21.5)
     # Verify preset_mode is saved
     assert saved_data["zones"]["zone1"]["preset_mode"] == "eco"
     # Verify used_duration is saved
-    assert saved_data["zones"]["zone1"]["used_duration"] == 1234.5
+    assert saved_data["zones"]["zone1"]["used_duration"] == pytest.approx(1234.5)
 
 
 async def test_coordinator_handles_invalid_timestamp_format(


### PR DESCRIPTION
## Summary

- Use `pytest.approx()` for float assertions in `test_coordinator_save_state_format` where values pass through EMA smoothing during `coordinator.async_refresh()`, causing IEEE 754 rounding drift (e.g. `21.500000000000004 != 21.5`)
- Add CLAUDE.md guideline on when to use `pytest.approx()` vs `==` for float comparisons in tests
- Audited all other test files — remaining float assertions are either already using `pytest.approx()`, operate on clamped/exact values, or are direct assign-and-read without computation

## Test plan

- [x] Full test suite passes (521/521)
- [x] Previously-flaky test passes 20/20 runs
- [x] Full test suite passes 20/20 runs
- [x] Ruff format, ruff check, ty check all pass
- [x] Diff coverage passes (no production code changed)

Resolves #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)