### PR TITLE
Add flow-rate-aware zone scheduling

### DIFF
--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -66,6 +66,9 @@ CONF_OUTDOOR_TEMP_WARM = "outdoor_temp_warm"
 CONF_OUTDOOR_TEMP_COLD = "outdoor_temp_cold"
 CONF_SUPPLY_TEMP_WARM = "supply_temp_warm"
 CONF_SUPPLY_TEMP_COLD = "supply_temp_cold"
+CONF_NOMINAL_FLOW_RATE = "nominal_flow_rate"
+CONF_OPTIMAL_FLOW_RATE_MIN = "optimal_flow_rate_min"
+CONF_OPTIMAL_FLOW_RATE_MAX = "optimal_flow_rate_max"
 
 
 def get_timing_schema(timing: TimingDefaults | None = None) -> vol.Schema:
@@ -295,8 +298,8 @@ def get_zone_schema(
                 )
             ),
             vol.Optional(
-                "nominal_flow_rate",
-                description={"suggested_value": defaults.get("nominal_flow_rate")},
+                CONF_NOMINAL_FLOW_RATE,
+                description={"suggested_value": defaults.get(CONF_NOMINAL_FLOW_RATE)},
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=UI_NOMINAL_FLOW_RATE["min"],
@@ -348,8 +351,8 @@ def get_zone_entities_schema(
                 selector.EntitySelectorConfig(domain="binary_sensor", multiple=True)
             ),
             vol.Optional(
-                "nominal_flow_rate",
-                description={"suggested_value": defaults.get("nominal_flow_rate")},
+                CONF_NOMINAL_FLOW_RATE,
+                description={"suggested_value": defaults.get(CONF_NOMINAL_FLOW_RATE)},
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=UI_NOMINAL_FLOW_RATE["min"],
@@ -573,10 +576,10 @@ def build_zone_data(user_input: dict[str, Any]) -> dict[str, Any]:
         "presets": dict(DEFAULT_PRESETS),
     }
     if (
-        "nominal_flow_rate" in user_input
-        and user_input["nominal_flow_rate"] is not None
+        CONF_NOMINAL_FLOW_RATE in user_input
+        and user_input[CONF_NOMINAL_FLOW_RATE] is not None
     ):
-        data["nominal_flow_rate"] = user_input["nominal_flow_rate"]
+        data[CONF_NOMINAL_FLOW_RATE] = user_input[CONF_NOMINAL_FLOW_RATE]
     return data
 
 
@@ -940,15 +943,19 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             new_flow: dict[str, float] = {}
             if (
-                "optimal_flow_rate_min" in user_input
-                and user_input["optimal_flow_rate_min"] is not None
+                CONF_OPTIMAL_FLOW_RATE_MIN in user_input
+                and user_input[CONF_OPTIMAL_FLOW_RATE_MIN] is not None
             ):
-                new_flow["optimal_flow_rate_min"] = user_input["optimal_flow_rate_min"]
+                new_flow[CONF_OPTIMAL_FLOW_RATE_MIN] = user_input[
+                    CONF_OPTIMAL_FLOW_RATE_MIN
+                ]
             if (
-                "optimal_flow_rate_max" in user_input
-                and user_input["optimal_flow_rate_max"] is not None
+                CONF_OPTIMAL_FLOW_RATE_MAX in user_input
+                and user_input[CONF_OPTIMAL_FLOW_RATE_MAX] is not None
             ):
-                new_flow["optimal_flow_rate_max"] = user_input["optimal_flow_rate_max"]
+                new_flow[CONF_OPTIMAL_FLOW_RATE_MAX] = user_input[
+                    CONF_OPTIMAL_FLOW_RATE_MAX
+                ]
 
             # Update the controller subentry with new flow scheduling
             for subentry in self.config_entry.subentries.values():
@@ -969,10 +976,10 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema(
                 {
                     vol.Optional(
-                        "optimal_flow_rate_min",
+                        CONF_OPTIMAL_FLOW_RATE_MIN,
                         description={
                             "suggested_value": flow_scheduling.get(
-                                "optimal_flow_rate_min"
+                                CONF_OPTIMAL_FLOW_RATE_MIN
                             )
                         },
                     ): selector.NumberSelector(
@@ -985,10 +992,10 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
                         )
                     ),
                     vol.Optional(
-                        "optimal_flow_rate_max",
+                        CONF_OPTIMAL_FLOW_RATE_MAX,
                         description={
                             "suggested_value": flow_scheduling.get(
-                                "optimal_flow_rate_max"
+                                CONF_OPTIMAL_FLOW_RATE_MAX
                             )
                         },
                     ): selector.NumberSelector(
@@ -1072,12 +1079,12 @@ class ZoneSubentryFlowHandler(ConfigSubentryFlow):
             }
             # Handle optional flow rate (store if provided, remove if cleared)
             if (
-                "nominal_flow_rate" in user_input
-                and user_input["nominal_flow_rate"] is not None
+                CONF_NOMINAL_FLOW_RATE in user_input
+                and user_input[CONF_NOMINAL_FLOW_RATE] is not None
             ):
-                new_data["nominal_flow_rate"] = user_input["nominal_flow_rate"]
+                new_data[CONF_NOMINAL_FLOW_RATE] = user_input[CONF_NOMINAL_FLOW_RATE]
             else:
-                new_data.pop("nominal_flow_rate", None)
+                new_data.pop(CONF_NOMINAL_FLOW_RATE, None)
             LOGGER.debug("Updating zone entities: %s", new_data["id"])
             return self.async_update_and_abort(
                 self._get_entry(),

--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -32,6 +32,8 @@ from .const import (
     SUBENTRY_TYPE_CONTROLLER,
     SUBENTRY_TYPE_ZONE,
     UI_HEATING_CURVE_SUPPLY,
+    UI_NOMINAL_FLOW_RATE,
+    UI_OPTIMAL_FLOW_RATE,
     UI_OUTDOOR_TEMP,
     UI_PRESET_TEMPERATURE,
     UI_SETPOINT_DEFAULT,
@@ -292,6 +294,18 @@ def get_zone_schema(
                     mode=selector.NumberSelectorMode.BOX,
                 )
             ),
+            vol.Optional(
+                "nominal_flow_rate",
+                description={"suggested_value": defaults.get("nominal_flow_rate")},
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=UI_NOMINAL_FLOW_RATE["min"],
+                    max=UI_NOMINAL_FLOW_RATE["max"],
+                    step=UI_NOMINAL_FLOW_RATE["step"],
+                    unit_of_measurement="L/min",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
         }
     )
 
@@ -332,6 +346,18 @@ def get_zone_entities_schema(
                 "window_sensors", default=defaults.get("window_sensors", [])
             ): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="binary_sensor", multiple=True)
+            ),
+            vol.Optional(
+                "nominal_flow_rate",
+                description={"suggested_value": defaults.get("nominal_flow_rate")},
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=UI_NOMINAL_FLOW_RATE["min"],
+                    max=UI_NOMINAL_FLOW_RATE["max"],
+                    step=UI_NOMINAL_FLOW_RATE["step"],
+                    unit_of_measurement="L/min",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
             ),
         }
     )
@@ -521,7 +547,7 @@ def build_presets_from_input(user_input: dict[str, Any]) -> dict[str, float]:
 def build_zone_data(user_input: dict[str, Any]) -> dict[str, Any]:
     """Build zone data from user input."""
     zone_id = user_input.get("zone_id") or slugify(user_input["name"])
-    return {
+    data: dict[str, Any] = {
         "id": zone_id,
         "name": user_input["name"],
         "circuit_type": user_input.get("circuit_type", CircuitType.REGULAR),
@@ -546,6 +572,12 @@ def build_zone_data(user_input: dict[str, Any]) -> dict[str, Any]:
         ),
         "presets": dict(DEFAULT_PRESETS),
     }
+    if (
+        "nominal_flow_rate" in user_input
+        and user_input["nominal_flow_rate"] is not None
+    ):
+        data["nominal_flow_rate"] = user_input["nominal_flow_rate"]
+    return data
 
 
 class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -641,7 +673,12 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
         """Show menu with configuration options."""
         return self.async_show_menu(
             step_id="init",
-            menu_options=["control_entities", "timing", "heat_accounting"],
+            menu_options=[
+                "control_entities",
+                "timing",
+                "heat_accounting",
+                "flow_scheduling",
+            ],
         )
 
     async def async_step_control_entities(
@@ -886,6 +923,87 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
             ),
         )
 
+    async def async_step_flow_scheduling(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Configure flow scheduling parameters (optimal flow rate bounds)."""
+        # Get flow scheduling from controller subentry if it exists
+        flow_scheduling: dict[str, Any] = {}
+        for subentry in self.config_entry.subentries.values():
+            if subentry.subentry_type == SUBENTRY_TYPE_CONTROLLER:
+                stored = subentry.data.get("flow_scheduling")
+                if stored is not None:
+                    flow_scheduling = stored
+                break
+
+        if user_input is not None:
+            new_flow: dict[str, float] = {}
+            if (
+                "optimal_flow_rate_min" in user_input
+                and user_input["optimal_flow_rate_min"] is not None
+            ):
+                new_flow["optimal_flow_rate_min"] = user_input["optimal_flow_rate_min"]
+            if (
+                "optimal_flow_rate_max" in user_input
+                and user_input["optimal_flow_rate_max"] is not None
+            ):
+                new_flow["optimal_flow_rate_max"] = user_input["optimal_flow_rate_max"]
+
+            # Update the controller subentry with new flow scheduling
+            for subentry in self.config_entry.subentries.values():
+                if subentry.subentry_type == SUBENTRY_TYPE_CONTROLLER:
+                    existing_data = dict(subentry.data)
+                    existing_data["flow_scheduling"] = new_flow
+                    self.hass.config_entries.async_update_subentry(
+                        self.config_entry,
+                        subentry,
+                        data=existing_data,
+                    )
+                    break
+
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="flow_scheduling",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        "optimal_flow_rate_min",
+                        description={
+                            "suggested_value": flow_scheduling.get(
+                                "optimal_flow_rate_min"
+                            )
+                        },
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=UI_OPTIMAL_FLOW_RATE["min"],
+                            max=UI_OPTIMAL_FLOW_RATE["max"],
+                            step=UI_OPTIMAL_FLOW_RATE["step"],
+                            unit_of_measurement="L/min",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Optional(
+                        "optimal_flow_rate_max",
+                        description={
+                            "suggested_value": flow_scheduling.get(
+                                "optimal_flow_rate_max"
+                            )
+                        },
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=UI_OPTIMAL_FLOW_RATE["min"],
+                            max=UI_OPTIMAL_FLOW_RATE["max"],
+                            step=UI_OPTIMAL_FLOW_RATE["step"],
+                            unit_of_measurement="L/min",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                }
+            ),
+        )
+
 
 class ZoneSubentryFlowHandler(ConfigSubentryFlow):
     """Handle subentry flow for adding and modifying zones."""
@@ -952,6 +1070,14 @@ class ZoneSubentryFlowHandler(ConfigSubentryFlow):
                 "circuit_type": user_input.get("circuit_type", CircuitType.REGULAR),
                 "window_sensors": user_input.get("window_sensors", []),
             }
+            # Handle optional flow rate (store if provided, remove if cleared)
+            if (
+                "nominal_flow_rate" in user_input
+                and user_input["nominal_flow_rate"] is not None
+            ):
+                new_data["nominal_flow_rate"] = user_input["nominal_flow_rate"]
+            else:
+                new_data.pop("nominal_flow_rate", None)
             LOGGER.debug("Updating zone entities: %s", new_data["id"])
             return self.async_update_and_abort(
                 self._get_entry(),

--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -215,7 +215,6 @@ DEFAULT_HEAT_SUPPLY_COEFFICIENT_THRESHOLD = 10.0  # 10% min supply coefficient f
 # Flow monitoring defaults
 DEFAULT_SUPPLY_TARGET_TEMP = 40.0
 DEFAULT_SUPPLY_COEFFICIENT_CAP = 200.0  # Maximum supply coefficient percentage
-
 # Heating curve defaults (outdoor temp compensation)
 DEFAULT_OUTDOOR_TEMP_WARM = 15.0  # Outdoor temp at warm design point (°C)
 DEFAULT_OUTDOOR_TEMP_COLD = -10.0  # Outdoor temp at cold design point (°C)
@@ -252,6 +251,10 @@ UI_TEMP_EMA_TIME_CONSTANT = {"min": 0, "max": 1800, "step": 60}  # 0-30 minutes
 
 # UI validation constraints for preset temperatures
 UI_PRESET_TEMPERATURE = {"min": 5.0, "max": 35.0, "step": 0.5}
+
+# Flow rate defaults and UI constraints (litres per minute)
+UI_NOMINAL_FLOW_RATE = {"min": 0.1, "max": 20.0, "step": 0.1}
+UI_OPTIMAL_FLOW_RATE = {"min": 0.1, "max": 100.0, "step": 0.1}
 
 # Icons
 ICON_PID_ERROR_THRESHOLD = 0.1

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -9,6 +9,9 @@ from typing import TYPE_CHECKING, Any
 from .config_flow import (
     CONF_DHW_ACTIVE_ENTITY,
     CONF_HEAT_REQUEST_ENTITY,
+    CONF_NOMINAL_FLOW_RATE,
+    CONF_OPTIMAL_FLOW_RATE_MAX,
+    CONF_OPTIMAL_FLOW_RATE_MIN,
     CONF_OUTDOOR_TEMP_ENTITY,
     CONF_PUMP_REQUEST_ENTITY,
     CONF_SUMMER_MODE_ENTITY,
@@ -265,7 +268,7 @@ class UFHControllerDataUpdateCoordinator(
                     temp_ema_time_constant=zone_data.get(
                         "temp_ema_time_constant", DEFAULT_TEMP_EMA_TIME_CONSTANT
                     ),
-                    nominal_flow_rate=zone_data.get("nominal_flow_rate"),
+                    nominal_flow_rate=zone_data.get(CONF_NOMINAL_FLOW_RATE),
                 )
             )
 
@@ -289,8 +292,8 @@ class UFHControllerDataUpdateCoordinator(
             summer_mode_entity=data.get(CONF_SUMMER_MODE_ENTITY),
             supply_temp_entity=data.get(CONF_SUPPLY_TEMP_ENTITY),
             outdoor_temp_entity=data.get(CONF_OUTDOOR_TEMP_ENTITY),
-            optimal_flow_rate_min=flow_scheduling.get("optimal_flow_rate_min"),
-            optimal_flow_rate_max=flow_scheduling.get("optimal_flow_rate_max"),
+            optimal_flow_rate_min=flow_scheduling.get(CONF_OPTIMAL_FLOW_RATE_MIN),
+            optimal_flow_rate_max=flow_scheduling.get(CONF_OPTIMAL_FLOW_RATE_MAX),
             heating_curve=heating_curve,
             timing=timing,
             zones=zones,

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -193,11 +193,13 @@ class UFHControllerDataUpdateCoordinator(
         """Build HeatingController from config entry."""
         data = entry.data
 
-        # Get timing from controller subentry, fall back to options for migration
+        # Get timing and flow scheduling from controller subentry
         timing_opts: dict[str, Any] = {}
+        flow_scheduling: dict[str, Any] = {}
         for subentry in entry.subentries.values():
             if subentry.subentry_type == SUBENTRY_TYPE_CONTROLLER:
                 timing_opts = subentry.data.get("timing", {})
+                flow_scheduling = subentry.data.get("flow_scheduling", {})
                 break
 
         timing = TimingConfig(
@@ -263,6 +265,7 @@ class UFHControllerDataUpdateCoordinator(
                     temp_ema_time_constant=zone_data.get(
                         "temp_ema_time_constant", DEFAULT_TEMP_EMA_TIME_CONSTANT
                     ),
+                    nominal_flow_rate=zone_data.get("nominal_flow_rate"),
                 )
             )
 
@@ -286,6 +289,8 @@ class UFHControllerDataUpdateCoordinator(
             summer_mode_entity=data.get(CONF_SUMMER_MODE_ENTITY),
             supply_temp_entity=data.get(CONF_SUPPLY_TEMP_ENTITY),
             outdoor_temp_entity=data.get(CONF_OUTDOOR_TEMP_ENTITY),
+            optimal_flow_rate_min=flow_scheduling.get("optimal_flow_rate_min"),
+            optimal_flow_rate_max=flow_scheduling.get("optimal_flow_rate_max"),
             heating_curve=heating_curve,
             timing=timing,
             zones=zones,

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -24,6 +24,7 @@ from custom_components.ufh_controller.const import (
 from .heating_curve import HeatingCurveConfig, calculate_supply_target
 from .history import get_observation_start
 from .pid import PIDController
+from .scheduler import apply_flow_constraint
 from .zone import (
     CircuitType,
     ZoneAction,
@@ -67,6 +68,8 @@ class ControllerConfig:
     summer_mode_entity: str | None = None
     supply_temp_entity: str | None = None
     outdoor_temp_entity: str | None = None
+    optimal_flow_rate_min: float | None = None
+    optimal_flow_rate_max: float | None = None
     heating_curve: HeatingCurveConfig = field(default_factory=HeatingCurveConfig)
     timing: TimingConfig = field(default_factory=TimingConfig)
     zones: list[ZoneConfig] = field(default_factory=list)
@@ -441,7 +444,7 @@ class HeatingController:
             now=now,
         )
 
-        # Phase 3: Evaluate flush zones with explicit flush_request parameter
+        # Phase 3: Evaluate flush zones
         for zone_id, runtime in self._zones.items():
             if runtime.config.circuit_type == CircuitType.FLUSH:
                 valve_actions[zone_id] = evaluate_zone(
@@ -450,6 +453,14 @@ class HeatingController:
                     self.config.timing,
                     flush_request=flush_request,
                 )
+
+        # Phase 4: Apply flow constraint to ALL zones together
+        if self.config.optimal_flow_rate_max is not None:
+            valve_actions = apply_flow_constraint(
+                desired_actions=valve_actions,
+                zones=self._zones,
+                max_flow_rate=self.config.optimal_flow_rate_max,
+            )
 
         # Pump request: any zone with confirmed flow
         pump_request = any(rt.state.flow for rt in self._zones.values())
@@ -464,6 +475,17 @@ class HeatingController:
             rd > self.config.timing.closing_warning_duration
             for rd in remaining_durations.values()
         )
+
+        # Flow minimum gating: suppress heat request when aggregate flow is
+        # below the configured minimum (latent heat mode)
+        if heat_request and self.config.optimal_flow_rate_min is not None:
+            total_active_flow = sum(
+                rt.config.nominal_flow_rate
+                for rt in self._zones.values()
+                if rt.state.flow and rt.config.nominal_flow_rate is not None
+            )
+            if total_active_flow < self.config.optimal_flow_rate_min:
+                heat_request = False
 
         return ControllerActions(
             valve_actions=valve_actions,

--- a/custom_components/ufh_controller/core/scheduler.py
+++ b/custom_components/ufh_controller/core/scheduler.py
@@ -1,0 +1,83 @@
+"""
+Flow-rate-aware zone scheduling for Underfloor Heating Controller.
+
+This module provides post-processing of zone actions to constrain aggregate
+flow rate within configured bounds. It is called after per-zone evaluation
+and before flush logic.
+"""
+
+from __future__ import annotations
+
+from .zone import ZoneAction, ZoneRuntime
+
+
+def apply_flow_constraint(
+    desired_actions: dict[str, ZoneAction],
+    zones: dict[str, ZoneRuntime],
+    max_flow_rate: float | None,
+) -> dict[str, ZoneAction]:
+    """
+    Constrain zone TURN_ON actions to keep aggregate flow within max_flow_rate.
+
+    Zones already ON (STAY_ON) are committed and cannot be preempted. TURN_ON
+    candidates are sorted by remaining quota descending (front-loading: zones
+    needing the most time get priority). Zones without a nominal_flow_rate pass
+    through unconstrained.
+
+    If a single zone's flow exceeds remaining capacity and no other zones are
+    running, it turns on anyway (never starve a zone).
+
+    Args:
+        desired_actions: Zone ID → ZoneAction from evaluate_zone().
+        zones: Zone ID → ZoneRuntime for flow rate and state lookup.
+        max_flow_rate: Upper bound on aggregate flow (L/min).
+
+    Returns:
+        Updated actions dict with some TURN_ON demoted to STAY_OFF.
+
+    """
+    # unbounded max flow rate returns desired actions
+    if max_flow_rate is None:
+        return desired_actions
+
+    # Committed flow from zones that are staying on
+    committed_flow = 0.0
+    for zone_id, action in desired_actions.items():
+        if action == ZoneAction.STAY_ON:
+            flow_rate = zones[zone_id].config.nominal_flow_rate
+            if flow_rate is not None:
+                committed_flow += flow_rate
+
+    # Collect TURN_ON candidates that have a flow rate
+    candidates: list[tuple[str, float, float]] = []
+    for zone_id, action in desired_actions.items():
+        if action != ZoneAction.TURN_ON:
+            continue
+        flow_rate = zones[zone_id].config.nominal_flow_rate
+        if flow_rate is None:
+            # No flow rate configured — pass through unconstrained
+            continue
+        remaining_quota = (
+            zones[zone_id].state.requested_duration - zones[zone_id].state.used_duration
+        )
+        candidates.append((zone_id, remaining_quota, flow_rate))
+
+    if not candidates:
+        return desired_actions
+
+    # Sort by remaining quota descending (front-load high-demand zones)
+    candidates.sort(key=lambda c: c[1], reverse=True)
+
+    result = dict(desired_actions)
+    for zone_id, _remaining_quota, flow_rate in candidates:
+        if committed_flow + flow_rate <= max_flow_rate:
+            # Fits within budget — allow TURN_ON
+            committed_flow += flow_rate
+        elif committed_flow == 0.0:
+            # No other zones running — never starve a single zone
+            committed_flow += flow_rate
+        else:
+            # Exceeds budget — demote to STAY_OFF
+            result[zone_id] = ZoneAction.STAY_OFF
+
+    return result

--- a/custom_components/ufh_controller/core/zone.py
+++ b/custom_components/ufh_controller/core/zone.py
@@ -143,6 +143,7 @@ class ZoneConfig:
     integral_min: float = DEFAULT_PID["integral_min"]
     integral_max: float = DEFAULT_PID["integral_max"]
     temp_ema_time_constant: int = DEFAULT_TEMP_EMA_TIME_CONSTANT
+    nominal_flow_rate: float | None = None
 
 
 class ZoneRuntime:

--- a/custom_components/ufh_controller/strings.json
+++ b/custom_components/ufh_controller/strings.json
@@ -24,7 +24,8 @@
         "menu_options": {
           "control_entities": "Control Entities",
           "timing": "Timing Parameters",
-          "heat_accounting": "Heat Accounting"
+          "heat_accounting": "Heat Accounting",
+          "flow_scheduling": "Flow Scheduling"
         }
       },
       "control_entities": {
@@ -70,6 +71,18 @@
           "supply_temp_cold": "Target supply temperature at the cold design point (e.g., 45°C for UFH)."
         }
       },
+      "flow_scheduling": {
+        "title": "Flow Scheduling",
+        "description": "Configure flow rate bounds for zone scheduling. When set, the controller constrains how many zones can be ON simultaneously to keep aggregate flow within these bounds.",
+        "data": {
+          "optimal_flow_rate_min": "Minimum flow rate",
+          "optimal_flow_rate_max": "Maximum flow rate"
+        },
+        "data_description": {
+          "optimal_flow_rate_min": "Suppress boiler heat request when aggregate flow from requesting zones is below this value (latent heat mode). Leave empty to disable.",
+          "optimal_flow_rate_max": "Maximum aggregate flow rate. Zones are scheduled to keep total flow at or below this limit. Leave empty to disable flow constraint."
+        }
+      },
       "zone_entities": {
         "title": "Zone Entities",
         "description": "Configure zone hardware mappings.",
@@ -78,7 +91,11 @@
           "temp_sensor": "Temperature sensor",
           "valve_switch": "Valve switch",
           "circuit_type": "Circuit type",
-          "window_sensors": "Window sensors"
+          "window_sensors": "Window sensors",
+          "nominal_flow_rate": "Nominal flow rate"
+        },
+        "data_description": {
+          "nominal_flow_rate": "Water flow rate when this zone's valve is open (L/min). Used for flow-rate-aware scheduling. Leave empty if unknown."
         }
       },
       "temperature_control": {
@@ -157,7 +174,11 @@
             "temp_ema_time_constant": "Temperature smoothing time constant",
             "kp": "PID proportional gain (Kp)",
             "ki": "PID integral gain (Ki)",
-            "kd": "PID derivative gain (Kd)"
+            "kd": "PID derivative gain (Kd)",
+            "nominal_flow_rate": "Nominal flow rate"
+          },
+          "data_description": {
+            "nominal_flow_rate": "Water flow rate when this zone's valve is open (L/min). Used for flow-rate-aware scheduling. Leave empty if unknown."
           }
         },
         "reconfigure": {
@@ -176,7 +197,11 @@
             "temp_sensor": "Temperature sensor",
             "valve_switch": "Valve switch",
             "circuit_type": "Circuit type",
-            "window_sensors": "Window sensors"
+            "window_sensors": "Window sensors",
+            "nominal_flow_rate": "Nominal flow rate"
+          },
+          "data_description": {
+            "nominal_flow_rate": "Water flow rate when this zone's valve is open (L/min). Used for flow-rate-aware scheduling. Leave empty if unknown."
           }
         },
         "temperature_control": {

--- a/custom_components/ufh_controller/translations/en.json
+++ b/custom_components/ufh_controller/translations/en.json
@@ -24,7 +24,8 @@
         "menu_options": {
           "control_entities": "Control Entities",
           "timing": "Timing Parameters",
-          "heat_accounting": "Heat Accounting"
+          "heat_accounting": "Heat Accounting",
+          "flow_scheduling": "Flow Scheduling"
         }
       },
       "control_entities": {
@@ -70,6 +71,18 @@
           "supply_temp_cold": "Target supply temperature at the cold design point (e.g., 45°C for UFH)."
         }
       },
+      "flow_scheduling": {
+        "title": "Flow Scheduling",
+        "description": "Configure flow rate bounds for zone scheduling. When set, the controller constrains how many zones can be ON simultaneously to keep aggregate flow within these bounds.",
+        "data": {
+          "optimal_flow_rate_min": "Minimum flow rate",
+          "optimal_flow_rate_max": "Maximum flow rate"
+        },
+        "data_description": {
+          "optimal_flow_rate_min": "Suppress boiler heat request when aggregate flow from requesting zones is below this value (latent heat mode). Leave empty to disable.",
+          "optimal_flow_rate_max": "Maximum aggregate flow rate. Zones are scheduled to keep total flow at or below this limit. Leave empty to disable flow constraint."
+        }
+      },
       "zone_entities": {
         "title": "Zone Entities",
         "description": "Configure zone hardware mappings.",
@@ -78,7 +91,11 @@
           "temp_sensor": "Temperature sensor",
           "valve_switch": "Valve switch",
           "circuit_type": "Circuit type",
-          "window_sensors": "Window sensors"
+          "window_sensors": "Window sensors",
+          "nominal_flow_rate": "Nominal flow rate"
+        },
+        "data_description": {
+          "nominal_flow_rate": "Water flow rate when this zone's valve is open (L/min). Used for flow-rate-aware scheduling. Leave empty if unknown."
         }
       },
       "temperature_control": {
@@ -157,7 +174,11 @@
             "temp_ema_time_constant": "Temperature smoothing time constant",
             "kp": "PID proportional gain (Kp)",
             "ki": "PID integral gain (Ki)",
-            "kd": "PID derivative gain (Kd)"
+            "kd": "PID derivative gain (Kd)",
+            "nominal_flow_rate": "Nominal flow rate"
+          },
+          "data_description": {
+            "nominal_flow_rate": "Water flow rate when this zone's valve is open (L/min). Used for flow-rate-aware scheduling. Leave empty if unknown."
           }
         },
         "reconfigure": {
@@ -176,7 +197,11 @@
             "temp_sensor": "Temperature sensor",
             "valve_switch": "Valve switch",
             "circuit_type": "Circuit type",
-            "window_sensors": "Window sensors"
+            "window_sensors": "Window sensors",
+            "nominal_flow_rate": "Nominal flow rate"
+          },
+          "data_description": {
+            "nominal_flow_rate": "Water flow rate when this zone's valve is open (L/min). Used for flow-rate-aware scheduling. Leave empty if unknown."
           }
         },
         "temperature_control": {


### PR DESCRIPTION
## Summary
- Add per-zone `nominal_flow_rate` configuration (L/min) for flow-rate-aware scheduling
- Add controller-level `optimal_flow_rate_min` and `optimal_flow_rate_max` bounds via a new "Flow Scheduling" options menu
- Introduce `core/scheduler.py` with `apply_flow_constraint()` to cap aggregate flow by demoting TURN_ON actions to STAY_OFF when the budget is exceeded (front-loading zones with highest remaining quota)
- Suppress boiler heat request when aggregate flow from active zones is below the configured minimum (latent heat mode)

## Test plan
- [ ] Unit tests for `apply_flow_constraint()` covering: unconstrained pass-through, budget capping, starvation prevention, zones without flow rate
- [ ] Integration tests for flow minimum gating of heat request
- [ ] Config flow tests for the new flow scheduling options step
- [ ] Verify diff coverage meets 100% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)