### PR TITLE
Adjust min run time check using supply coefficient

### DIFF
--- a/custom_components/ufh_controller/core/zone.py
+++ b/custom_components/ufh_controller/core/zone.py
@@ -536,8 +536,18 @@ def evaluate_zone(  # noqa: PLR0911
             return ZoneAction.STAY_ON
 
         remaining_quota = zone.requested_duration - zone.used_duration
-        if remaining_quota < timing.min_run_time:
-            # Not enough quota left to justify turning on
+
+        # Estimate wall clock time for the remaining quota.
+        # When supply coefficient is available, quota depletes at
+        # (supply_coefficient / 100) rate, so wall clock time is longer
+        # when supply is low and shorter when supply is high.
+        if zone.supply_coefficient is not None and zone.supply_coefficient > 0:
+            estimated_runtime = remaining_quota / (zone.supply_coefficient / 100.0)
+        else:
+            estimated_runtime = remaining_quota
+
+        if estimated_runtime < timing.min_run_time:
+            # Not enough wall clock time to justify turning on
             return ZoneAction.STAY_OFF if valve_off else ZoneAction.TURN_OFF
 
         if controller.dhw_active and zone.circuit_type == CircuitType.REGULAR:

--- a/custom_components/ufh_controller/core/zone.py
+++ b/custom_components/ufh_controller/core/zone.py
@@ -537,17 +537,13 @@ def evaluate_zone(  # noqa: PLR0911
 
         remaining_quota = zone.requested_duration - zone.used_duration
 
-        # Estimate wall clock time for the remaining quota.
-        # When supply coefficient is available, quota depletes at
-        # (supply_coefficient / 100) rate, so wall clock time is longer
-        # when supply is low and shorter when supply is high.
+        # Convert remaining quota to estimated wall clock time via supply coefficient
         if zone.supply_coefficient is not None and zone.supply_coefficient > 0:
             estimated_runtime = remaining_quota / (zone.supply_coefficient / 100.0)
         else:
             estimated_runtime = remaining_quota
 
         if estimated_runtime < timing.min_run_time:
-            # Not enough wall clock time to justify turning on
             return ZoneAction.STAY_OFF if valve_off else ZoneAction.TURN_OFF
 
         if controller.dhw_active and zone.circuit_type == CircuitType.REGULAR:

--- a/custom_components/ufh_controller/core/zone.py
+++ b/custom_components/ufh_controller/core/zone.py
@@ -539,7 +539,10 @@ def evaluate_zone(  # noqa: PLR0911
 
         # Convert remaining quota to estimated wall clock time via supply coefficient
         if zone.supply_coefficient is not None and zone.supply_coefficient > 0:
-            estimated_runtime = remaining_quota / (zone.supply_coefficient / 100.0)
+            estimated_runtime = max(
+                remaining_quota,
+                remaining_quota / (zone.supply_coefficient / 100.0),
+            )
         else:
             estimated_runtime = remaining_quota
 

--- a/docs/control_algorithm.md
+++ b/docs/control_algorithm.md
@@ -72,8 +72,9 @@ The zone evaluation follows a priority-based decision tree:
 3. **Quota-based scheduling:** For zones that haven't met their quota:
    - If valve is already on: stay on (commands are re-sent to prevent relay timeout)
    - If estimated wall clock runtime is less than `min_run_time`: stay off (not worth a short run).
-     When a supply coefficient is available, remaining quota is converted to estimated wall clock time:
-     `estimated_runtime = remaining_quota / (supply_coefficient / 100)`.
+     When a supply coefficient is available, remaining quota is converted to estimated wall clock time
+     (capped at remaining quota so coefficients above 100% never shorten the estimate):
+     `estimated_runtime = max(remaining_quota, remaining_quota / (supply_coefficient / 100))`.
      Without a supply sensor, remaining quota is compared directly.
    - If DHW is active and this is a regular circuit currently off: stay off (DHW priority)
    - Otherwise: turn on

--- a/docs/control_algorithm.md
+++ b/docs/control_algorithm.md
@@ -71,7 +71,10 @@ The zone evaluation follows a priority-based decision tree:
 
 3. **Quota-based scheduling:** For zones that haven't met their quota:
    - If valve is already on: stay on (commands are re-sent to prevent relay timeout)
-   - If remaining quota is less than `min_run_time`: stay off (not worth a short run)
+   - If estimated wall clock runtime is less than `min_run_time`: stay off (not worth a short run).
+     When a supply coefficient is available, remaining quota is converted to estimated wall clock time:
+     `estimated_runtime = remaining_quota / (supply_coefficient / 100)`.
+     Without a supply sensor, remaining quota is compared directly.
    - If DHW is active and this is a regular circuit currently off: stay off (DHW priority)
    - Otherwise: turn on
 

--- a/docs/heat_accounting.md
+++ b/docs/heat_accounting.md
@@ -49,13 +49,16 @@ whether to open a valve, the controller estimates the wall clock time the valve 
 the remaining quota by the supply coefficient ratio:
 
 ```
-estimated_runtime = remaining_quota / (supply_coefficient / 100)
+estimated_runtime = max(remaining_quota, remaining_quota / (supply_coefficient / 100))
 ```
+
+The `max()` ensures that coefficients above 100% never shorten the estimate below the remaining quota itself —
+the valve cannot run for less wall clock time than the quota it needs to deliver.
 
 At 50% supply coefficient, 300 seconds of remaining quota translates to an estimated 600 seconds of wall clock
 time — enough to justify opening the valve even though the raw quota is below the minimum run time threshold.
-Conversely, at 200% supply coefficient, 600 seconds of quota would only last 300 seconds of wall clock time,
-preventing a cycle that would be too brief.
+At 200%, the division would yield 300 seconds, but the cap keeps the estimate at the full 600 seconds of
+remaining quota.
 
 This adjustment does **not** affect the closing warning duration, which remains in scheduled heating duration
 time for stable boiler shutdown coordination.

--- a/docs/heat_accounting.md
+++ b/docs/heat_accounting.md
@@ -42,6 +42,24 @@ means the zone receives more benefit, reflected in a coefficient above 100%.
 
 The coefficient is capped at 200% to prevent runaway accumulation.
 
+### Minimum Run Time Adjustment
+
+The supply coefficient also affects the minimum run time check that prevents short valve cycles. When deciding
+whether to open a valve, the controller estimates the wall clock time the valve would remain open by dividing
+the remaining quota by the supply coefficient ratio:
+
+```
+estimated_runtime = remaining_quota / (supply_coefficient / 100)
+```
+
+At 50% supply coefficient, 300 seconds of remaining quota translates to an estimated 600 seconds of wall clock
+time — enough to justify opening the valve even though the raw quota is below the minimum run time threshold.
+Conversely, at 200% supply coefficient, 600 seconds of quota would only last 300 seconds of wall clock time,
+preventing a cycle that would be too brief.
+
+This adjustment does **not** affect the closing warning duration, which remains in scheduled heating duration
+time for stable boiler shutdown coordination.
+
 ### Used Duration Accumulation
 
 Each update cycle, `used_duration` accumulates when the zone is receiving heat:

--- a/tests/integration/test_zone_evaluation.py
+++ b/tests/integration/test_zone_evaluation.py
@@ -443,6 +443,154 @@ class TestEvaluateZoneQuotaScheduling:
         assert result == ZoneAction.TURN_OFF
 
 
+class TestEvaluateZoneMinRunTimeSupplyAdjustment:
+    """
+    Test min_run_time check adjusted for supply coefficient.
+
+    When supply coefficient is available, the remaining quota is converted to
+    estimated wall clock time before comparing against min_run_time.
+
+    Wall clock estimate = remaining_quota / (supply_coefficient / 100)
+    """
+
+    @pytest.fixture
+    def timing(self) -> TimingConfig:
+        """Create timing config with 540s min run time."""
+        return TimingConfig(min_run_time=540)
+
+    @pytest.fixture
+    def controller(self) -> ControllerState:
+        """Create default controller state."""
+        return ControllerState(started_at=NOW)
+
+    def test_low_supply_coefficient_extends_estimated_runtime(
+        self, timing: TimingConfig, controller: ControllerState
+    ) -> None:
+        """
+        Low supply coefficient means quota depletes slowly, wall clock time is longer.
+
+        remaining_quota=300s, supply_coefficient=50%
+        estimated_runtime = 300 / 0.50 = 600s > 540 min_run_time → TURN_ON
+        Without adjustment, 300 < 540 → would stay off.
+        """
+        zone = ZoneState(
+            zone_id="test",
+            valve_state=ValveState.OFF,
+            requested_duration=1000.0,
+            used_duration=700.0,  # 300 remaining quota
+            supply_coefficient=50.0,
+        )
+        result = evaluate_zone(zone, controller, timing)
+        assert result == ZoneAction.TURN_ON
+
+    def test_high_supply_coefficient_shortens_estimated_runtime(
+        self, timing: TimingConfig, controller: ControllerState
+    ) -> None:
+        """
+        High supply coefficient means quota depletes fast, wall clock time is shorter.
+
+        remaining_quota=600s, supply_coefficient=200%
+        estimated_runtime = 600 / 2.0 = 300s < 540 min_run_time → STAY_OFF
+        Without adjustment, 600 > 540 → would turn on.
+        """
+        zone = ZoneState(
+            zone_id="test",
+            valve_state=ValveState.OFF,
+            requested_duration=1000.0,
+            used_duration=400.0,  # 600 remaining quota
+            supply_coefficient=200.0,
+        )
+        result = evaluate_zone(zone, controller, timing)
+        assert result == ZoneAction.STAY_OFF
+
+    def test_no_supply_coefficient_falls_back_to_direct_comparison(
+        self, timing: TimingConfig, controller: ControllerState
+    ) -> None:
+        """Without supply sensor, remaining quota is compared directly (unchanged)."""
+        zone = ZoneState(
+            zone_id="test",
+            valve_state=ValveState.OFF,
+            requested_duration=1000.0,
+            used_duration=700.0,  # 300 remaining < 540
+            supply_coefficient=None,
+        )
+        result = evaluate_zone(zone, controller, timing)
+        assert result == ZoneAction.STAY_OFF
+
+    def test_zero_supply_coefficient_falls_back_to_direct_comparison(
+        self, timing: TimingConfig, controller: ControllerState
+    ) -> None:
+        """Zero supply coefficient falls back to direct comparison."""
+        zone = ZoneState(
+            zone_id="test",
+            valve_state=ValveState.OFF,
+            requested_duration=1000.0,
+            used_duration=700.0,  # 300 remaining < 540
+            supply_coefficient=0.0,
+        )
+        result = evaluate_zone(zone, controller, timing)
+        assert result == ZoneAction.STAY_OFF
+
+    def test_exactly_at_threshold_after_adjustment(
+        self, timing: TimingConfig, controller: ControllerState
+    ) -> None:
+        """
+        Estimated runtime exactly at min_run_time allows turn on.
+
+        remaining_quota=270s, supply_coefficient=50%
+        estimated_runtime = 270 / 0.50 = 540s == 540 min_run_time → TURN_ON
+        (not strictly less than, so valve can open)
+        """
+        zone = ZoneState(
+            zone_id="test",
+            valve_state=ValveState.OFF,
+            requested_duration=1000.0,
+            used_duration=730.0,  # 270 remaining quota
+            supply_coefficient=50.0,
+        )
+        result = evaluate_zone(zone, controller, timing)
+        assert result == ZoneAction.TURN_ON
+
+    def test_just_below_threshold_after_adjustment(
+        self, timing: TimingConfig, controller: ControllerState
+    ) -> None:
+        """
+        Estimated runtime just below min_run_time prevents turn on.
+
+        remaining_quota=269s, supply_coefficient=50%
+        estimated_runtime = 269 / 0.50 = 538s < 540 min_run_time → STAY_OFF
+        """
+        zone = ZoneState(
+            zone_id="test",
+            valve_state=ValveState.OFF,
+            requested_duration=1000.0,
+            used_duration=731.0,  # 269 remaining quota
+            supply_coefficient=50.0,
+        )
+        result = evaluate_zone(zone, controller, timing)
+        assert result == ZoneAction.STAY_OFF
+
+    def test_supply_100_percent_same_as_no_adjustment(
+        self, timing: TimingConfig, controller: ControllerState
+    ) -> None:
+        """
+        At 100% supply coefficient, adjustment is identity (no change).
+
+        remaining_quota=300s, supply_coefficient=100%
+        estimated_runtime = 300 / 1.0 = 300s < 540 → STAY_OFF
+        Same result as without supply coefficient.
+        """
+        zone = ZoneState(
+            zone_id="test",
+            valve_state=ValveState.OFF,
+            requested_duration=1000.0,
+            used_duration=700.0,  # 300 remaining
+            supply_coefficient=100.0,
+        )
+        result = evaluate_zone(zone, controller, timing)
+        assert result == ZoneAction.STAY_OFF
+
+
 class TestEvaluateZoneDHWBlocking:
     """Test DHW blocking for regular circuits."""
 

--- a/tests/integration/test_zone_evaluation.py
+++ b/tests/integration/test_zone_evaluation.py
@@ -461,8 +461,10 @@ class TestEvaluateZoneMinRunTimeSupplyAdjustment:
         [
             # 50%: 300 remaining / 0.50 = 600s > 540 → on
             (700.0, 50.0, ZoneAction.TURN_ON),
-            # 200%: 600 remaining / 2.0 = 300s < 540 → off
-            (400.0, 200.0, ZoneAction.STAY_OFF),
+            # 200%: 600 remaining, capped at remaining_quota (600) > 540 → on
+            (400.0, 200.0, ZoneAction.TURN_ON),
+            # 200%: 400 remaining, capped at remaining_quota (400) < 540 → off
+            (600.0, 200.0, ZoneAction.STAY_OFF),
             # No sensor: 300 remaining compared directly < 540 → off
             (700.0, None, ZoneAction.STAY_OFF),
             # 0%: fallback to direct, 300 < 540 → off

--- a/tests/integration/test_zone_evaluation.py
+++ b/tests/integration/test_zone_evaluation.py
@@ -444,14 +444,7 @@ class TestEvaluateZoneQuotaScheduling:
 
 
 class TestEvaluateZoneMinRunTimeSupplyAdjustment:
-    """
-    Test min_run_time check adjusted for supply coefficient.
-
-    When supply coefficient is available, the remaining quota is converted to
-    estimated wall clock time before comparing against min_run_time.
-
-    Wall clock estimate = remaining_quota / (supply_coefficient / 100)
-    """
+    """Test min_run_time check adjusted to wall clock time via supply coefficient."""
 
     @pytest.fixture
     def timing(self) -> TimingConfig:
@@ -463,132 +456,42 @@ class TestEvaluateZoneMinRunTimeSupplyAdjustment:
         """Create default controller state."""
         return ControllerState(started_at=NOW)
 
-    def test_low_supply_coefficient_extends_estimated_runtime(
-        self, timing: TimingConfig, controller: ControllerState
+    @pytest.mark.parametrize(
+        ("used_duration", "supply_coefficient", "expected"),
+        [
+            # 50%: 300 remaining / 0.50 = 600s > 540 → on
+            (700.0, 50.0, ZoneAction.TURN_ON),
+            # 200%: 600 remaining / 2.0 = 300s < 540 → off
+            (400.0, 200.0, ZoneAction.STAY_OFF),
+            # No sensor: 300 remaining compared directly < 540 → off
+            (700.0, None, ZoneAction.STAY_OFF),
+            # 0%: fallback to direct, 300 < 540 → off
+            (700.0, 0.0, ZoneAction.STAY_OFF),
+            # 50%: 270 remaining / 0.50 = 540s, not strictly < → on
+            (730.0, 50.0, ZoneAction.TURN_ON),
+            # 50%: 269 remaining / 0.50 = 538s < 540 → off
+            (731.0, 50.0, ZoneAction.STAY_OFF),
+            # 100%: identity, 300 / 1.0 = 300s < 540 → off
+            (700.0, 100.0, ZoneAction.STAY_OFF),
+        ],
+    )
+    def test_min_run_time_with_supply_adjustment(
+        self,
+        timing: TimingConfig,
+        controller: ControllerState,
+        used_duration: float,
+        supply_coefficient: float | None,
+        expected: ZoneAction,
     ) -> None:
-        """
-        Low supply coefficient means quota depletes slowly, wall clock time is longer.
-
-        remaining_quota=300s, supply_coefficient=50%
-        estimated_runtime = 300 / 0.50 = 600s > 540 min_run_time → TURN_ON
-        Without adjustment, 300 < 540 → would stay off.
-        """
+        """Remaining quota is converted to wall clock time via supply coefficient."""
         zone = ZoneState(
             zone_id="test",
             valve_state=ValveState.OFF,
             requested_duration=1000.0,
-            used_duration=700.0,  # 300 remaining quota
-            supply_coefficient=50.0,
+            used_duration=used_duration,
+            supply_coefficient=supply_coefficient,
         )
-        result = evaluate_zone(zone, controller, timing)
-        assert result == ZoneAction.TURN_ON
-
-    def test_high_supply_coefficient_shortens_estimated_runtime(
-        self, timing: TimingConfig, controller: ControllerState
-    ) -> None:
-        """
-        High supply coefficient means quota depletes fast, wall clock time is shorter.
-
-        remaining_quota=600s, supply_coefficient=200%
-        estimated_runtime = 600 / 2.0 = 300s < 540 min_run_time → STAY_OFF
-        Without adjustment, 600 > 540 → would turn on.
-        """
-        zone = ZoneState(
-            zone_id="test",
-            valve_state=ValveState.OFF,
-            requested_duration=1000.0,
-            used_duration=400.0,  # 600 remaining quota
-            supply_coefficient=200.0,
-        )
-        result = evaluate_zone(zone, controller, timing)
-        assert result == ZoneAction.STAY_OFF
-
-    def test_no_supply_coefficient_falls_back_to_direct_comparison(
-        self, timing: TimingConfig, controller: ControllerState
-    ) -> None:
-        """Without supply sensor, remaining quota is compared directly (unchanged)."""
-        zone = ZoneState(
-            zone_id="test",
-            valve_state=ValveState.OFF,
-            requested_duration=1000.0,
-            used_duration=700.0,  # 300 remaining < 540
-            supply_coefficient=None,
-        )
-        result = evaluate_zone(zone, controller, timing)
-        assert result == ZoneAction.STAY_OFF
-
-    def test_zero_supply_coefficient_falls_back_to_direct_comparison(
-        self, timing: TimingConfig, controller: ControllerState
-    ) -> None:
-        """Zero supply coefficient falls back to direct comparison."""
-        zone = ZoneState(
-            zone_id="test",
-            valve_state=ValveState.OFF,
-            requested_duration=1000.0,
-            used_duration=700.0,  # 300 remaining < 540
-            supply_coefficient=0.0,
-        )
-        result = evaluate_zone(zone, controller, timing)
-        assert result == ZoneAction.STAY_OFF
-
-    def test_exactly_at_threshold_after_adjustment(
-        self, timing: TimingConfig, controller: ControllerState
-    ) -> None:
-        """
-        Estimated runtime exactly at min_run_time allows turn on.
-
-        remaining_quota=270s, supply_coefficient=50%
-        estimated_runtime = 270 / 0.50 = 540s == 540 min_run_time → TURN_ON
-        (not strictly less than, so valve can open)
-        """
-        zone = ZoneState(
-            zone_id="test",
-            valve_state=ValveState.OFF,
-            requested_duration=1000.0,
-            used_duration=730.0,  # 270 remaining quota
-            supply_coefficient=50.0,
-        )
-        result = evaluate_zone(zone, controller, timing)
-        assert result == ZoneAction.TURN_ON
-
-    def test_just_below_threshold_after_adjustment(
-        self, timing: TimingConfig, controller: ControllerState
-    ) -> None:
-        """
-        Estimated runtime just below min_run_time prevents turn on.
-
-        remaining_quota=269s, supply_coefficient=50%
-        estimated_runtime = 269 / 0.50 = 538s < 540 min_run_time → STAY_OFF
-        """
-        zone = ZoneState(
-            zone_id="test",
-            valve_state=ValveState.OFF,
-            requested_duration=1000.0,
-            used_duration=731.0,  # 269 remaining quota
-            supply_coefficient=50.0,
-        )
-        result = evaluate_zone(zone, controller, timing)
-        assert result == ZoneAction.STAY_OFF
-
-    def test_supply_100_percent_same_as_no_adjustment(
-        self, timing: TimingConfig, controller: ControllerState
-    ) -> None:
-        """
-        At 100% supply coefficient, adjustment is identity (no change).
-
-        remaining_quota=300s, supply_coefficient=100%
-        estimated_runtime = 300 / 1.0 = 300s < 540 → STAY_OFF
-        Same result as without supply coefficient.
-        """
-        zone = ZoneState(
-            zone_id="test",
-            valve_state=ValveState.OFF,
-            requested_duration=1000.0,
-            used_duration=700.0,  # 300 remaining
-            supply_coefficient=100.0,
-        )
-        result = evaluate_zone(zone, controller, timing)
-        assert result == ZoneAction.STAY_OFF
+        assert evaluate_zone(zone, controller, timing) == expected
 
 
 class TestEvaluateZoneDHWBlocking:


### PR DESCRIPTION
## Summary
This change adjusts the minimum run time check to account for supply coefficient, converting remaining quota to estimated wall clock time before comparing against the minimum run time threshold. This allows zones with low supply coefficients (e.g., 50%) to justify opening the valve even when remaining quota is below the minimum threshold, since they will run longer in wall clock time to deliver that quota.

## Key Changes
- **Zone evaluation logic**: Modified `evaluate_zone()` to calculate `estimated_runtime` by dividing remaining quota by the supply coefficient ratio, with a cap ensuring coefficients above 100% never shorten the estimate below the remaining quota itself
- **Supply coefficient handling**: When supply coefficient is unavailable or zero, remaining quota is compared directly (fallback behavior)
- **Documentation**: Updated control algorithm and heat accounting documentation to explain the adjustment formula and its rationale

## Implementation Details
- The estimated runtime calculation uses: `max(remaining_quota, remaining_quota / (supply_coefficient / 100))`
- The `max()` ensures that high supply coefficients (>100%) cannot artificially reduce the estimated runtime below the actual remaining quota
- This adjustment applies only to the minimum run time check; closing warning duration remains in scheduled heating duration time for boiler coordination
- Comprehensive test coverage added with 8 parametrized test cases covering edge cases: low/high coefficients, missing sensor, zero coefficient, and boundary conditions

https://claude.ai/code/session_013SwWsKFztNmQndV81AdQpT