### PR TITLE
Drop redundant hasattr(runtime_data) checks

### DIFF
--- a/custom_components/ufh_controller/__init__.py
+++ b/custom_components/ufh_controller/__init__.py
@@ -116,7 +116,7 @@ async def async_unload_entry(
     LOGGER.debug("Unloading Underfloor Heating Controller entry: %s", entry.entry_id)
 
     # Save state before unloading
-    if hasattr(entry, "runtime_data") and entry.runtime_data is not None:
+    if entry.runtime_data is not None:
         coordinator = entry.runtime_data.coordinator
         await coordinator.async_save_state()
 
@@ -135,7 +135,7 @@ async def _async_handle_config_update(
     parameter changes can be applied in-place without entity recreation.
     """
     # Check if entry has runtime data (might not during initial setup)
-    if not hasattr(entry, "runtime_data") or entry.runtime_data is None:
+    if entry.runtime_data is None:
         LOGGER.debug("No runtime data, performing full reload")
         await hass.config_entries.async_reload(entry.entry_id)
         return


### PR DESCRIPTION
## Summary

Modern Home Assistant always initializes `ConfigEntry.runtime_data` to `None` before setup runs, so the attribute is guaranteed to exist. The `hasattr(entry, "runtime_data")` guards were leftover defensiveness from an older pattern.

- `async_unload_entry`: `hasattr(...) and entry.runtime_data is not None` → `entry.runtime_data is not None`
- `_async_handle_config_update`: `not hasattr(...) or entry.runtime_data is None` → `entry.runtime_data is None`

## Testing

- `uv run pytest` → 652 passed, 7 xfailed
- `uv run ruff format .` / `uv run ruff check` → clean
- `uv run ty check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)