### PR TITLE
Respect operation mode in fail-safe fallbacks

### DIFF
--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -601,7 +601,10 @@ class UFHControllerDataUpdateCoordinator(
             )
 
         # If ALL zones are in fail-safe, execute controller-level fail-safe
-        if self._controller.status == ControllerStatus.FAIL_SAFE:
+        if (
+            self._controller.status == ControllerStatus.FAIL_SAFE
+            and self._controller.mode != OperationMode.OFF
+        ):
             await self._execute_fail_safe_actions()
             return self._build_state_dict()
 

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -534,23 +534,11 @@ class UFHControllerDataUpdateCoordinator(
         await self._execute_heat_request(heat_request=False)
         await self._execute_pump_request(pump_request=False)
 
-        # Set summer mode to 'auto' to pass control back to the boiler
-        summer_entity = self._controller.config.summer_mode_entity
-        if summer_entity:
-            # Track expected state for external change detection
-            self._entities_expected_states[summer_entity] = SummerMode.AUTO
-
-            await self.hass.services.async_call(
-                Platform.SELECT,
-                SERVICE_SELECT_OPTION,
-                {"entity_id": summer_entity, "option": SummerMode.AUTO},
-            )
-            LOGGER.debug(
-                "Select service '%s' called for %s with option '%s'",
-                SERVICE_SELECT_OPTION,
-                summer_entity,
-                SummerMode.AUTO,
-            )
+        summer_mode = self._controller.get_summer_mode_value(
+            heat_request=False, fail_safe=True
+        )
+        if summer_mode is not None:
+            await self._set_summer_mode(summer_mode)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via controller logic."""
@@ -648,11 +636,12 @@ class UFHControllerDataUpdateCoordinator(
                 heat_request=actions.heat_request, force_update=force_update
             )
 
-            # Derive and update summer mode from heat_request
-            summer_mode = (
-                SummerMode.WINTER if actions.heat_request else SummerMode.SUMMER
+            summer_mode = self._controller.get_summer_mode_value(
+                heat_request=actions.heat_request,
+                fail_safe=self._controller.any_zone_in_fail_safe,
             )
-            await self._set_summer_mode(summer_mode, force_update=force_update)
+            if summer_mode is not None:
+                await self._set_summer_mode(summer_mode, force_update=force_update)
 
         return self._build_state_dict()
 
@@ -999,22 +988,10 @@ class UFHControllerDataUpdateCoordinator(
     async def _set_summer_mode(
         self, summer_mode: SummerMode, *, force_update: bool = False
     ) -> None:
-        """
-        Set boiler summer mode to specified value.
-
-        Safety: If ANY zone is in fail-safe, summer mode is forced to 'auto'
-        to allow physical fallback valves to receive heated water.
-        """
+        """Set boiler summer mode to the value decided by the caller."""
         entity_id = self._controller.config.summer_mode_entity
         if entity_id is None:
             return
-
-        # Safety check: if any zone is in fail-safe, force summer mode to 'auto'
-        if self._controller.any_zone_in_fail_safe:
-            summer_mode = SummerMode.AUTO
-            LOGGER.debug(
-                "Zone(s) in fail-safe, forcing summer mode to 'auto' for fallbacks"
-            )
 
         current_state = self.hass.states.get(entity_id)
         if current_state is None:

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -506,16 +506,21 @@ class HeatingController:
 
         return actions
 
-    def get_summer_mode_value(self, *, heat_request: bool) -> str | None:
+    def get_summer_mode_value(
+        self, *, heat_request: bool, fail_safe: bool = False
+    ) -> SummerMode | None:
         """
         Determine the summer mode value for the boiler.
 
         Args:
             heat_request: Current heat request state.
+            fail_safe: Whether zone control has been lost (any zone in
+                fail-safe). Only heat mode delegates to the boiler.
 
         Returns:
-            SummerMode.WINTER for heating, SummerMode.SUMMER for no heating,
-            or None if not applicable.
+            SummerMode.AUTO to hand control to the boiler, SummerMode.WINTER
+            for heating, SummerMode.SUMMER for no heating, or None if not
+            applicable.
 
         """
         if self.config.summer_mode_entity is None:
@@ -526,13 +531,17 @@ class HeatingController:
         if mode == OperationMode.OFF:
             return None
 
-        if mode in (OperationMode.FLUSH, OperationMode.ALL_OFF):
+        # Explicit modes state user intent; a zone failure must not override it
+        if mode in (OperationMode.FLUSH, OperationMode.CYCLE, OperationMode.ALL_OFF):
             return SummerMode.SUMMER
 
         if mode == OperationMode.ALL_ON:
             return SummerMode.WINTER
 
-        # Heat and cycle modes depend on heat request
+        # Heat is the only automatic mode: delegate so fallback thermostats get supply
+        if fail_safe:
+            return SummerMode.AUTO
+
         return SummerMode.WINTER if heat_request else SummerMode.SUMMER
 
     def update_dhw_state(self, *, dhw_active: bool, now: datetime) -> None:

--- a/docs/fault_isolation.md
+++ b/docs/fault_isolation.md
@@ -41,6 +41,14 @@ Derived from zone statuses:
 
 The `binary_sensor.{controller_id}_status` entity shows `on` (problem) when degraded or fail-safe.
 
+When the controller status is `fail_safe`, all valves are closed and pump and heat
+request are turned off.
+
+Zone failure tracking runs in every operation mode, so the controller can reach
+`fail_safe` even in `off` mode. Because `off` mode takes no actions at all, the
+fail-safe actions are skipped there and no outputs are written; the status is
+still reported.
+
 ## Summer Mode Safety
 
 When a zone is in fail-safe its valve is forced closed, so the controller can no

--- a/docs/fault_isolation.md
+++ b/docs/fault_isolation.md
@@ -43,7 +43,27 @@ The `binary_sensor.{controller_id}_status` entity shows `on` (problem) when degr
 
 ## Summer Mode Safety
 
-When ANY zone is in fail-safe:
-- Summer mode forced to "auto"
-- Allows physical fallback valves to receive heated water
-- Ensures heating available via physical fallback mechanisms
+When a zone is in fail-safe its valve is forced closed, so the controller can no
+longer deliver heat to it. In `heat` mode the controller therefore sets summer
+mode to "auto", handing the heating circuit back to the boiler so valve
+controllers acting as offline thermostats can still receive heated water.
+
+This applies in `heat` mode only, whether one zone or all zones have failed. Every
+other mode is an explicit instruction that a zone failure must not override:
+
+| Mode | Summer mode while any zone is in fail-safe |
+|------|--------------------------------------------|
+| `heat` | `auto` — delegated to the boiler |
+| `flush` | `summer` — circulation only, no firing |
+| `cycle` | `summer` — maintenance rotation, no firing |
+| `all_on` | `winter` |
+| `all_off` | `summer` |
+| `off` | not written |
+
+Delegating in a mode that must not fire the boiler would let the boiler heat on
+its own curve while the controller reports no heat request. Because the failed
+zones' valves are closed, that heat would be driven into whichever zones remain
+open, with no PID, quota or window blocking applied.
+
+Frost protection does not depend on this: the boiler applies its own internal
+frost protection regardless of summer mode.

--- a/docs/operation_modes.md
+++ b/docs/operation_modes.md
@@ -12,6 +12,8 @@ Default mode. Full PID control with quota-based scheduling.
 - Window blocking active
 - DHW priority active (if configured)
 - Post-DHW residual heat capture active (if configured)
+- Boiler summer_mode follows heat request, or "auto" when any zone is in fail-safe
+  (see [Fault Isolation](fault_isolation.md#summer-mode-safety))
 
 ### Flush Mode (`flush`)
 
@@ -32,6 +34,7 @@ Diagnostic mode that rotates through zones.
 - Hours 1-7: zones open sequentially
 - Pump request: flow-gated (on when the active zone has confirmed flow)
 - Heat request OFF
+- Boiler summer_mode set to "summer" (rotation only, no firing)
 
 ### All On Mode (`all_on`)
 
@@ -54,5 +57,10 @@ Manual override - heating disabled.
 ### Off Mode (`off`)
 
 Controller inactive. No actions taken, entities remain in last state.
+
+---
+
+Except in `heat` mode, the summer_mode values above are enforced even when zones
+enter fail-safe. See [Fault Isolation](fault_isolation.md#summer-mode-safety).
 
 ---

--- a/docs/operation_modes.md
+++ b/docs/operation_modes.md
@@ -56,7 +56,8 @@ Manual override - heating disabled.
 
 ### Off Mode (`off`)
 
-Controller inactive. No actions taken, entities remain in last state.
+Controller inactive. No actions taken, entities remain in last state. This holds
+even if zones enter fail-safe, which is still tracked and reported.
 
 ---
 

--- a/tests/scenarios/test_coordinator_failure.py
+++ b/tests/scenarios/test_coordinator_failure.py
@@ -13,6 +13,7 @@ from custom_components.ufh_controller.const import (
     FAIL_SAFE_TIMEOUT,
     INITIALIZING_TIMEOUT,
     ControllerStatus,
+    OperationMode,
     SummerMode,
     ValveState,
     ZoneStatus,
@@ -493,43 +494,6 @@ class TestZoneIsolation:
 
         assert zone1.state.zone_status == ZoneStatus.NORMAL
 
-    async def test_summer_mode_forced_auto_when_zone_in_fail_safe(
-        self,
-        hass: HomeAssistant,
-        mock_config_entry_multiple_zones: MockConfigEntry,
-    ) -> None:
-        """Test summer mode is forced to auto when any zone is in fail-safe."""
-        mock_config_entry_multiple_zones.add_to_hass(hass)
-        hass.states.async_set("sensor.zone1_temp", "20.5")
-        hass.states.async_set("sensor.zone2_temp", "20.5")
-        hass.states.async_set("switch.zone1_valve", "off")
-        hass.states.async_set("switch.zone2_valve", "off")
-        hass.states.async_set("select.summer_mode", "winter")
-
-        # Register select service
-        summer_mode_calls: list[str] = []
-
-        async def track_select_call(call: ServiceCall) -> None:
-            summer_mode_calls.append(call.data["option"])
-
-        hass.services.async_register("select", "select_option", track_select_call)
-
-        coordinator = UFHControllerDataUpdateCoordinator(
-            hass, mock_config_entry_multiple_zones
-        )
-
-        # Put zone2 into fail-safe
-        zone2 = coordinator._controller.get_zone_runtime("zone2")
-        assert zone2 is not None
-        zone2.state.zone_status = ZoneStatus.FAIL_SAFE
-
-        # Try to set summer mode to "winter"
-        # Without fail-safe zone, this would set to "winter"
-        # But with fail-safe zone, it should force to "auto"
-        await coordinator._set_summer_mode(SummerMode.WINTER)
-
-        assert "auto" in summer_mode_calls
-
     async def test_state_dict_includes_zone_status(
         self,
         hass: HomeAssistant,
@@ -869,3 +833,132 @@ class TestInitializingTimeout:
             f"after {INITIALIZING_TIMEOUT} seconds" in record.message
             for record in caplog.records  # type: ignore[union-attr]
         )
+
+
+class TestSummerModeFallbackRespectsMode:
+    """
+    Test the summer mode fallback honours the active operation mode.
+
+    Handing heating authority to the boiler with 'auto' is only appropriate in
+    heat mode, where the controller is actively heating and valve-controller
+    fallback thermostats may physically open a valve that needs supply. In every
+    explicit mode the user has already stated the intent, so a zone failure must
+    not silently override it.
+    """
+
+    @staticmethod
+    async def _run_loop_with_failed_zone(
+        hass: HomeAssistant,
+        entry: MockConfigEntry,
+        mode: OperationMode,
+    ) -> list[str]:
+        """
+        Run one control loop with zone2 in fail-safe and zone1 healthy.
+
+        Returns the summer mode options requested during that loop.
+        """
+        entry.add_to_hass(hass)
+        hass.states.async_set("sensor.zone1_temp", "20.5")
+        hass.states.async_set("sensor.zone2_temp", "unavailable")
+        hass.states.async_set("switch.zone1_valve", "on")
+        hass.states.async_set("switch.zone2_valve", "on")
+        hass.states.async_set("select.summer_mode", "winter")
+        hass.states.async_set("binary_sensor.dhw_active", "off")
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        summer_mode_calls: list[str] = []
+
+        async def track_select_call(call: ServiceCall) -> None:
+            summer_mode_calls.append(call.data["option"])
+
+        hass.services.async_register("select", "select_option", track_select_call)
+        hass.services.async_register("switch", "turn_on", AsyncMock())
+        hass.services.async_register("switch", "turn_off", AsyncMock())
+
+        coordinator = entry.runtime_data.coordinator
+        coordinator.controller.mode = mode
+
+        # Zone2 has been failing for longer than the fail-safe timeout
+        zone2 = coordinator.controller.get_zone_runtime("zone2")
+        assert zone2 is not None
+        zone2.state.last_successful_update = datetime.now(UTC) - timedelta(
+            seconds=FAIL_SAFE_TIMEOUT + 60
+        )
+
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        # Precondition: exactly one zone failed, so the controller is degraded
+        assert zone2.state.zone_status == ZoneStatus.FAIL_SAFE
+        assert coordinator.status == ControllerStatus.DEGRADED
+
+        return summer_mode_calls
+
+    async def test_flush_mode_keeps_summer(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_multiple_zones: MockConfigEntry,
+    ) -> None:
+        """
+        Test flush mode keeps summer when a zone fails.
+
+        Flush means circulate without firing the boiler. Delegating to 'auto'
+        here lets the boiler heat on its own curve, and with the failed zones'
+        valves forced shut all of that heat is driven into whichever loops
+        remain open.
+        """
+        calls = await self._run_loop_with_failed_zone(
+            hass, mock_config_entry_multiple_zones, OperationMode.FLUSH
+        )
+
+        assert SummerMode.AUTO not in calls
+        assert calls[-1] == SummerMode.SUMMER
+
+    async def test_all_off_mode_keeps_summer(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_multiple_zones: MockConfigEntry,
+    ) -> None:
+        """Test all_off mode keeps summer when a zone fails."""
+        calls = await self._run_loop_with_failed_zone(
+            hass, mock_config_entry_multiple_zones, OperationMode.ALL_OFF
+        )
+
+        assert SummerMode.AUTO not in calls
+        assert calls[-1] == SummerMode.SUMMER
+
+    async def test_all_on_mode_keeps_winter(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_multiple_zones: MockConfigEntry,
+    ) -> None:
+        """
+        Test all_on mode keeps winter when a zone fails.
+
+        Winter is already the seeded state, so the correct behaviour is to leave
+        it alone rather than to request anything.
+        """
+        calls = await self._run_loop_with_failed_zone(
+            hass, mock_config_entry_multiple_zones, OperationMode.ALL_ON
+        )
+
+        assert SummerMode.AUTO not in calls
+        assert all(option == SummerMode.WINTER for option in calls)
+
+    async def test_heat_mode_still_delegates_to_auto(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_multiple_zones: MockConfigEntry,
+    ) -> None:
+        """
+        Test heat mode still delegates to auto when a zone fails.
+
+        This is the behaviour the fallback exists for and must be preserved.
+        """
+        calls = await self._run_loop_with_failed_zone(
+            hass, mock_config_entry_multiple_zones, OperationMode.HEAT
+        )
+
+        assert calls[-1] == SummerMode.AUTO

--- a/tests/scenarios/test_coordinator_failure.py
+++ b/tests/scenarios/test_coordinator_failure.py
@@ -962,3 +962,99 @@ class TestSummerModeFallbackRespectsMode:
         )
 
         assert calls[-1] == SummerMode.AUTO
+
+
+class TestOffModeSkipsFailSafeActions:
+    """
+    Test off mode writes no outputs when the controller enters fail-safe.
+
+    Off mode means the integration takes no actions at all, leaving the manifold
+    to whatever else is managing it. Zone failure tracking still runs in off
+    mode, so the controller can reach fail-safe there; doing so must not start
+    driving valves, pump, heat request or summer mode.
+    """
+
+    async def test_off_mode_writes_nothing_in_fail_safe(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_all_entities: MockConfigEntry,
+    ) -> None:
+        """Test no service calls are made in off mode once all zones fail."""
+        mock_config_entry_all_entities.add_to_hass(hass)
+        hass.states.async_set("sensor.zone1_temp", "20.5")
+        hass.states.async_set("switch.zone1_valve", "on")
+        hass.states.async_set("switch.pump_request", "on")
+        hass.states.async_set("switch.heat_request", "on")
+        hass.states.async_set("select.summer_mode", "winter")
+        hass.states.async_set("binary_sensor.dhw_active", "off")
+
+        await hass.config_entries.async_setup(mock_config_entry_all_entities.entry_id)
+        await hass.async_block_till_done()
+
+        service_calls: list[str] = []
+
+        async def track_call(call: ServiceCall) -> None:
+            service_calls.append(f"{call.domain}.{call.service}")
+
+        hass.services.async_register("switch", "turn_on", track_call)
+        hass.services.async_register("switch", "turn_off", track_call)
+        hass.services.async_register("select", "select_option", track_call)
+
+        coordinator = mock_config_entry_all_entities.runtime_data.coordinator
+        coordinator.controller.mode = OperationMode.OFF
+
+        # The only zone has been failing for longer than the fail-safe timeout
+        hass.states.async_set("sensor.zone1_temp", "unavailable")
+        zone1 = coordinator.controller.get_zone_runtime("zone1")
+        assert zone1 is not None
+        zone1.state.last_successful_update = datetime.now(UTC) - timedelta(
+            seconds=FAIL_SAFE_TIMEOUT + 60
+        )
+
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        assert coordinator.status == ControllerStatus.FAIL_SAFE
+        assert service_calls == []
+
+    async def test_heat_mode_still_executes_fail_safe(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_all_entities: MockConfigEntry,
+    ) -> None:
+        """Test the fail-safe path still runs in heat mode."""
+        mock_config_entry_all_entities.add_to_hass(hass)
+        hass.states.async_set("sensor.zone1_temp", "20.5")
+        hass.states.async_set("switch.zone1_valve", "on")
+        hass.states.async_set("switch.pump_request", "on")
+        hass.states.async_set("switch.heat_request", "on")
+        hass.states.async_set("select.summer_mode", "winter")
+        hass.states.async_set("binary_sensor.dhw_active", "off")
+
+        await hass.config_entries.async_setup(mock_config_entry_all_entities.entry_id)
+        await hass.async_block_till_done()
+
+        service_calls: list[str] = []
+
+        async def track_call(call: ServiceCall) -> None:
+            service_calls.append(f"{call.domain}.{call.service}")
+
+        hass.services.async_register("switch", "turn_on", track_call)
+        hass.services.async_register("switch", "turn_off", track_call)
+        hass.services.async_register("select", "select_option", track_call)
+
+        coordinator = mock_config_entry_all_entities.runtime_data.coordinator
+
+        hass.states.async_set("sensor.zone1_temp", "unavailable")
+        zone1 = coordinator.controller.get_zone_runtime("zone1")
+        assert zone1 is not None
+        zone1.state.last_successful_update = datetime.now(UTC) - timedelta(
+            seconds=FAIL_SAFE_TIMEOUT + 60
+        )
+
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        assert coordinator.status == ControllerStatus.FAIL_SAFE
+        assert "switch.turn_off" in service_calls
+        assert "select.select_option" in service_calls

--- a/tests/scenarios/test_coordinator_state_tracking.py
+++ b/tests/scenarios/test_coordinator_state_tracking.py
@@ -131,12 +131,14 @@ async def test_fail_safe_sets_expected_state_for_summer_mode(
     """
     Test that fail-safe actions set expected state for summer mode.
 
-    During fail-safe, the coordinator resets summer mode to 'auto'. The expected
-    state must be set so this self-initiated change isn't treated as external.
+    During fail-safe in heat mode, the coordinator resets summer mode to 'auto'.
+    The expected state must be set so this self-initiated change isn't treated
+    as external.
     """
     mock_config_entry_all_entities.add_to_hass(hass)
     hass.states.async_set("sensor.zone1_temp", "20.5")
     hass.states.async_set("switch.zone1_valve", "on")
+    hass.states.async_set("select.summer_mode", "winter")
 
     # Register services needed by fail-safe actions
     hass.services.async_register("switch", "turn_off", AsyncMock())

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -780,6 +780,90 @@ class TestGetSummerModeValue:
         controller = HeatingController(config, started_at=NOW)
         assert controller.get_summer_mode_value(heat_request=False) == SummerMode.SUMMER
 
+    def test_cycle_mode_returns_summer(self) -> None:
+        """Test cycle mode returns summer (maintenance circulation only)."""
+        config = ControllerConfig(
+            controller_id="heating",
+            name="Heating",
+            summer_mode_entity="select.boiler_summer",
+            zones=[],
+        )
+        controller = HeatingController(config, started_at=NOW)
+        controller.mode = OperationMode.CYCLE
+        assert controller.get_summer_mode_value(heat_request=False) == SummerMode.SUMMER
+
+
+class TestGetSummerModeValueFailSafe:
+    """
+    Test get_summer_mode_value with fail_safe set.
+
+    Delegating to the boiler with 'auto' is only permitted in heat mode, where
+    the controller is actively heating and valve-controller fallback thermostats
+    may physically open a valve that needs supply. Every explicit mode keeps
+    enforcing its own value so a user instruction is never silently overridden.
+    """
+
+    @staticmethod
+    def _controller(mode: OperationMode) -> HeatingController:
+        """Build a controller with a summer mode entity in the given mode."""
+        config = ControllerConfig(
+            controller_id="heating",
+            name="Heating",
+            summer_mode_entity="select.boiler_summer",
+            zones=[],
+        )
+        controller = HeatingController(config, started_at=NOW)
+        controller.mode = mode
+        return controller
+
+    @pytest.mark.parametrize("heat_request", [True, False])
+    def test_heat_mode_delegates_to_auto(self, *, heat_request: bool) -> None:
+        """Test heat mode returns auto in fail-safe, whatever the heat request."""
+        controller = self._controller(OperationMode.HEAT)
+        assert (
+            controller.get_summer_mode_value(heat_request=heat_request, fail_safe=True)
+            == SummerMode.AUTO
+        )
+
+    @pytest.mark.parametrize(
+        "mode",
+        [OperationMode.FLUSH, OperationMode.CYCLE, OperationMode.ALL_OFF],
+    )
+    def test_no_heat_modes_keep_summer(self, mode: OperationMode) -> None:
+        """Test modes that must not fire the boiler stay on summer in fail-safe."""
+        controller = self._controller(mode)
+        assert (
+            controller.get_summer_mode_value(heat_request=False, fail_safe=True)
+            == SummerMode.SUMMER
+        )
+
+    def test_all_on_mode_keeps_winter(self) -> None:
+        """Test all_on stays on winter in fail-safe rather than delegating."""
+        controller = self._controller(OperationMode.ALL_ON)
+        assert (
+            controller.get_summer_mode_value(heat_request=True, fail_safe=True)
+            == SummerMode.WINTER
+        )
+
+    def test_off_mode_returns_none(self) -> None:
+        """Test off mode writes nothing even in fail-safe."""
+        controller = self._controller(OperationMode.OFF)
+        assert (
+            controller.get_summer_mode_value(heat_request=False, fail_safe=True) is None
+        )
+
+    def test_no_summer_mode_entity_returns_none(self) -> None:
+        """Test fail-safe does not invent a value when no entity is configured."""
+        config = ControllerConfig(
+            controller_id="heating",
+            name="Heating",
+            zones=[],
+        )
+        controller = HeatingController(config, started_at=NOW)
+        assert (
+            controller.get_summer_mode_value(heat_request=False, fail_safe=True) is None
+        )
+
 
 class TestComputeActionsWithFlushZones:
     """Test compute_actions method with flush circuit zones."""


### PR DESCRIPTION
## Problem

Two fail-safe paths write control outputs without consulting the active operation mode.

**1. The boiler summer mode fallback forced `auto` in every mode.** It fired as soon as *any* single zone entered fail-safe. In modes that must not fire the boiler (`flush`, `cycle`, `all_off`) this handed the heating circuit back to the boiler, which then heated on its own curve while the controller correctly reported no heat request.

Because a fail-safe zone also has its valve forced closed, that heat is driven into whichever zones are still healthy, with no PID, quota or window blocking applied. When a shared sensor transport fails, most zones fail together and a single surviving circuit absorbs the entire boiler output for as long as the outage lasts.

**2. The controller-level fail-safe branch ran in `off` mode.** `off` documents "no actions taken", but the branch returns before the mode is consulted. Zone failure tracking runs in every mode, so once all zones reached fail-safe the integration closed every valve and turned off pump and heat request. Reachable within two minutes of a restart, since the initialization timeout is 120 s and that branch is evaluated ahead of the initializing early return.

## Change

Delegating to the boiler with `auto` is now permitted only in `heat` mode — the one automatic mode, where valve controllers acting as offline thermostats may physically open a valve that needs supply. Every explicit mode keeps enforcing its own value, whether one zone or all zones have failed.

| Mode | Before, any zone in fail-safe | After |
|---|---|---|
| `heat` | `auto` | `auto` |
| `flush` | `auto` | `summer` |
| `cycle` | `auto` | `summer` |
| `all_on` | `auto` | `winter` |
| `all_off` | `auto` | `summer` |
| `off` | `auto` if all zones failed | not written |

The decision moves into `get_summer_mode_value`, which already knows the mode and was previously unreachable from the coordinator; `_set_summer_mode` becomes a plain setter. The `off` fix is a mode guard on the fail-safe branch, letting `off` fall through to the normal path where empty actions and unset requests leave every output untouched.

Frost protection is unaffected — the boiler applies its own internally, regardless of summer mode.

## Notes

- `cycle` moves off the `heat_request` branch onto the non-firing branch. No behaviour change, as cycle never requests heat.
- The fail-safe path now routes through `_set_summer_mode`, so it skips the call when the select entity is absent from the state machine, and tracks expected state as before.
- One existing test asserted the old unconditional `auto` and is replaced by mode-specific coverage.

## Verification

- Tests written first and confirmed failing, then fixed
- 666 passed, 7 xfailed; ruff format, ruff check and ty all clean
- 100% diff coverage vs `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)