### PR TITLE
Add configurable DHW priority levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ While generic thermostats adapt radiator or TRV logic to UFH, this integration i
 | | Generic Thermostats | This Integration |
 |---|---|---|
 | **Zone coordination** | Each zone fires the heat source independently | Zones aggregate demand into a single heat request with valve pre-opening |
-| **Hot water priority** | Unaware of DHW or fights for priority | Blocks new heating during DHW, captures residual heat after |
+| **Hot water priority** | Unaware of DHW or fights for priority | Parallel, partial or absolute priority; captures residual heat after |
 | **Quota fairness** | Time-based or none | Supply-temperature-weighted — zones aren't penalized for cold-start periods |
 | **UFH tuning** | Adapted from radiator/TRV logic | PID defaults, observation periods, and minimum run times designed for screed thermal mass |
 
@@ -98,6 +98,7 @@ Multiple UFH zones sharing one heat source need coordination that per-zone therm
 When domestic hot water is being heated, generic thermostats either fight the heat source for priority or don't know DHW is happening. This controller:
 
 - **Blocks new heating** during DHW — zones already flowing continue circulating, but new zones wait
+- **Closes every circuit** during DHW, if your boiler raises its flow temperature for the cylinder and nothing mixes or isolates the manifold (`absolute` priority)
 - **Captures residual heat** — after DHW finishes, hot water still in the system gets circulated through floors instead of wasted
 - **Configurable flush duration** — control how long post-DHW circulation runs
 

--- a/custom_components/ufh_controller/binary_sensor.py
+++ b/custom_components/ufh_controller/binary_sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import (
@@ -118,14 +117,11 @@ FLUSH_REQUEST_SENSOR = UFHControllerBinarySensorEntityDescription(
 
 def _dhw_block_attrs(data: dict[str, Any]) -> dict[str, Any]:
     """Return context explaining why circuits are held closed."""
-    block_until = data.get("dhw_block_until")
     return {
         "dhw_priority": data.get("dhw_priority"),
         "dhw_active": data.get("dhw_active"),
         "dhw_sensor_available": data.get("dhw_sensor_available"),
-        "dhw_block_until": (
-            block_until.isoformat() if isinstance(block_until, datetime) else None
-        ),
+        "dhw_block_until": data.get("dhw_block_until"),
     }
 
 

--- a/custom_components/ufh_controller/binary_sensor.py
+++ b/custom_components/ufh_controller/binary_sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import (
@@ -115,6 +116,26 @@ FLUSH_REQUEST_SENSOR = UFHControllerBinarySensorEntityDescription(
 )
 
 
+def _dhw_block_attrs(data: dict[str, Any]) -> dict[str, Any]:
+    """Return context explaining why circuits are held closed."""
+    block_until = data.get("dhw_block_until")
+    return {
+        "dhw_priority": data.get("dhw_priority"),
+        "dhw_active": data.get("dhw_active"),
+        "dhw_block_until": (
+            block_until.isoformat() if isinstance(block_until, datetime) else None
+        ),
+    }
+
+
+DHW_BLOCK_SENSOR = UFHControllerBinarySensorEntityDescription(
+    key="dhw_block",
+    translation_key="dhw_block",
+    value_fn=lambda data: bool(data.get("dhw_block")),
+    attrs_fn=_dhw_block_attrs,
+)
+
+
 async def async_setup_entry(
     _hass: HomeAssistant,
     entry: UFHControllerConfigEntry,
@@ -132,9 +153,10 @@ async def async_setup_entry(
             HEAT_REQUEST_SENSOR,
         ]
 
-        # Only create flush_request sensor if DHW entity is configured
+        # Only create DHW-derived sensors if the DHW entity is configured
         if entry.data.get("dhw_active_entity"):
             controller_descriptions.append(FLUSH_REQUEST_SENSOR)
+            controller_descriptions.append(DHW_BLOCK_SENSOR)
 
         async_add_entities(
             [

--- a/custom_components/ufh_controller/binary_sensor.py
+++ b/custom_components/ufh_controller/binary_sensor.py
@@ -74,9 +74,16 @@ def _status_value(data: dict[str, Any]) -> bool:
 
 
 def _status_attrs(data: dict[str, Any]) -> dict[str, Any]:
-    """Return additional status attributes."""
+    """
+    Return additional status attributes.
+
+    fail_safe_reason exists because a DHW sensor fault reaches fail-safe with
+    every zone still healthy, so zones_fail_safe reads 0 and the state would
+    otherwise look like a bug.
+    """
     return {
         "status": data.get("status"),
+        "fail_safe_reason": data.get("fail_safe_reason"),
         "zones_initializing": data.get("zones_initializing"),
         "zones_normal": data.get("zones_normal"),
         "zones_degraded": data.get("zones_degraded"),

--- a/custom_components/ufh_controller/binary_sensor.py
+++ b/custom_components/ufh_controller/binary_sensor.py
@@ -122,6 +122,7 @@ def _dhw_block_attrs(data: dict[str, Any]) -> dict[str, Any]:
     return {
         "dhw_priority": data.get("dhw_priority"),
         "dhw_active": data.get("dhw_active"),
+        "dhw_sensor_available": data.get("dhw_sensor_available"),
         "dhw_block_until": (
             block_until.isoformat() if isinstance(block_until, datetime) else None
         ),

--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import selector
 from slugify import slugify
 
 from .const import (
+    DEFAULT_DHW_PRIORITY,
     DEFAULT_OUTDOOR_TEMP_COLD,
     DEFAULT_OUTDOOR_TEMP_WARM,
     DEFAULT_PID,
@@ -41,12 +42,14 @@ from .const import (
     UI_TEMP_EMA_TIME_CONSTANT,
     UI_TIMING_CLOSING_WARNING,
     UI_TIMING_CONTROLLER_LOOP_INTERVAL,
+    UI_TIMING_DHW_RECOVERY_TIME,
     UI_TIMING_FLUSH_DURATION,
     UI_TIMING_MIN_RUN_TIME,
     UI_TIMING_OBSERVATION_PERIOD,
     UI_TIMING_VALVE_CLOSE_TIME,
     UI_TIMING_VALVE_OPEN_TIME,
     UI_TIMING_WINDOW_BLOCK_TIME,
+    DHWPriority,
     TimingDefaults,
 )
 from .core.zone import CircuitType
@@ -56,6 +59,7 @@ CONF_CONTROLLER_ID = "controller_id"
 CONF_PUMP_REQUEST_ENTITY = "pump_request_entity"
 CONF_HEAT_REQUEST_ENTITY = "heat_request_entity"
 CONF_DHW_ACTIVE_ENTITY = "dhw_active_entity"
+CONF_DHW_PRIORITY = "dhw_priority"
 CONF_SUMMER_MODE_ENTITY = "summer_mode_entity"
 CONF_SUPPLY_TEMP_ENTITY = "supply_temp_entity"
 CONF_SUPPLY_TARGET_TEMP = "supply_target_temp"
@@ -64,6 +68,17 @@ CONF_OUTDOOR_TEMP_WARM = "outdoor_temp_warm"
 CONF_OUTDOOR_TEMP_COLD = "outdoor_temp_cold"
 CONF_SUPPLY_TEMP_WARM = "supply_temp_warm"
 CONF_SUPPLY_TEMP_COLD = "supply_temp_cold"
+
+
+def get_dhw_priority_selector() -> selector.SelectSelector:
+    """Get the selector for DHW priority, translated via strings.json."""
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=[priority.value for priority in DHWPriority],
+            mode=selector.SelectSelectorMode.DROPDOWN,
+            translation_key=CONF_DHW_PRIORITY,
+        )
+    )
 
 
 def get_timing_schema(timing: TimingDefaults | None = None) -> vol.Schema:
@@ -174,6 +189,20 @@ def get_timing_schema(timing: TimingDefaults | None = None) -> vol.Schema:
                     min=UI_TIMING_FLUSH_DURATION["min"],
                     max=UI_TIMING_FLUSH_DURATION["max"],
                     step=UI_TIMING_FLUSH_DURATION["step"],
+                    unit_of_measurement=UnitOfTime.SECONDS,
+                )
+            ),
+            vol.Required(
+                "dhw_recovery_time",
+                default=timing.get(
+                    "dhw_recovery_time",
+                    DEFAULT_TIMING["dhw_recovery_time"],
+                ),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=UI_TIMING_DHW_RECOVERY_TIME["min"],
+                    max=UI_TIMING_DHW_RECOVERY_TIME["max"],
+                    step=UI_TIMING_DHW_RECOVERY_TIME["step"],
                     unit_of_measurement=UnitOfTime.SECONDS,
                 )
             ),
@@ -582,6 +611,9 @@ class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_PUMP_REQUEST_ENTITY: user_input.get(CONF_PUMP_REQUEST_ENTITY),
                     CONF_HEAT_REQUEST_ENTITY: user_input.get(CONF_HEAT_REQUEST_ENTITY),
                     CONF_DHW_ACTIVE_ENTITY: user_input.get(CONF_DHW_ACTIVE_ENTITY),
+                    CONF_DHW_PRIORITY: user_input.get(
+                        CONF_DHW_PRIORITY, DEFAULT_DHW_PRIORITY.value
+                    ),
                     CONF_SUMMER_MODE_ENTITY: user_input.get(CONF_SUMMER_MODE_ENTITY),
                 },
                 options={
@@ -605,6 +637,10 @@ class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(CONF_DHW_ACTIVE_ENTITY): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="binary_sensor")
                     ),
+                    vol.Required(
+                        CONF_DHW_PRIORITY,
+                        default=DEFAULT_DHW_PRIORITY.value,
+                    ): get_dhw_priority_selector(),
                     vol.Optional(CONF_SUMMER_MODE_ENTITY): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="select")
                     ),
@@ -656,6 +692,9 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_PUMP_REQUEST_ENTITY: user_input.get(CONF_PUMP_REQUEST_ENTITY),
                 CONF_HEAT_REQUEST_ENTITY: user_input.get(CONF_HEAT_REQUEST_ENTITY),
                 CONF_DHW_ACTIVE_ENTITY: user_input.get(CONF_DHW_ACTIVE_ENTITY),
+                CONF_DHW_PRIORITY: user_input.get(
+                    CONF_DHW_PRIORITY, DEFAULT_DHW_PRIORITY.value
+                ),
                 CONF_SUMMER_MODE_ENTITY: user_input.get(CONF_SUMMER_MODE_ENTITY),
             }
             self.hass.config_entries.async_update_entry(
@@ -699,6 +738,12 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
                     ): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="binary_sensor")
                     ),
+                    vol.Required(
+                        CONF_DHW_PRIORITY,
+                        default=current_data.get(
+                            CONF_DHW_PRIORITY, DEFAULT_DHW_PRIORITY.value
+                        ),
+                    ): get_dhw_priority_selector(),
                     vol.Optional(
                         CONF_SUMMER_MODE_ENTITY,
                         description={
@@ -735,6 +780,7 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
                 "window_block_time": int(user_input["window_block_time"]),
                 "controller_loop_interval": int(user_input["controller_loop_interval"]),
                 "flush_duration": int(user_input["flush_duration"]),
+                "dhw_recovery_time": int(user_input["dhw_recovery_time"]),
             }
 
             # Update the controller subentry with new timing

--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -70,6 +70,29 @@ CONF_SUPPLY_TEMP_WARM = "supply_temp_warm"
 CONF_SUPPLY_TEMP_COLD = "supply_temp_cold"
 
 
+def validate_dhw_priority(user_input: dict[str, Any]) -> dict[str, str]:
+    """
+    Reject a DHW priority that cannot function with the configured entities.
+
+    Absolute priority is inert without a DHW sensor: the controller never
+    learns that a charge is in progress, so no circuit is ever closed and the
+    dhw_block sensor is not even created. Someone who correctly identifies
+    their manifold as at-risk would be left unprotected with nothing in the UI
+    to reveal it, so this is an error rather than a silent no-op.
+
+    Args:
+        user_input: Submitted form values.
+
+    Returns:
+        Field-keyed errors, empty when the combination is usable.
+
+    """
+    priority = user_input.get(CONF_DHW_PRIORITY, DEFAULT_DHW_PRIORITY.value)
+    if priority == DHWPriority.ABSOLUTE and not user_input.get(CONF_DHW_ACTIVE_ENTITY):
+        return {CONF_DHW_PRIORITY: "dhw_priority_requires_sensor"}
+    return {}
+
+
 def get_dhw_priority_selector() -> selector.SelectSelector:
     """Get the selector for DHW priority, translated via strings.json."""
     return selector.SelectSelector(
@@ -590,6 +613,9 @@ class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            errors = validate_dhw_priority(user_input)
+
+        if user_input is not None and not errors:
             # Generate controller_id from name if not provided
             controller_id = user_input.get(CONF_CONTROLLER_ID) or slugify(
                 user_input[CONF_NAME]
@@ -685,7 +711,12 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
         user_input: dict[str, Any] | None = None,
     ) -> config_entries.ConfigFlowResult:
         """Configure control entities (heat request, summer mode, etc.)."""
+        errors: dict[str, str] = {}
+
         if user_input is not None:
+            errors = validate_dhw_priority(user_input)
+
+        if user_input is not None and not errors:
             # Update the config entry data with new control entities
             new_data = {
                 **self.config_entry.data,
@@ -703,8 +734,8 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
             )
             return self.async_create_entry(title="", data={})
 
-        # Get current values from config entry data
-        current_data = self.config_entry.data
+        # Redisplay the rejected input rather than discarding what was typed
+        current_data = {**self.config_entry.data, **(user_input or {})}
 
         return self.async_show_form(
             step_id="control_entities",
@@ -754,6 +785,7 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
                     ),
                 }
             ),
+            errors=errors,
         )
 
     async def async_step_timing(

--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -70,6 +70,11 @@ CONF_SUPPLY_TEMP_WARM = "supply_temp_warm"
 CONF_SUPPLY_TEMP_COLD = "supply_temp_cold"
 
 
+def _suggest(values: dict[str, Any], key: str) -> dict[str, Any]:
+    """Redisplay a submitted value, so a validation error costs no typing."""
+    return {"suggested_value": values.get(key)}
+
+
 def validate_dhw_priority(user_input: dict[str, Any]) -> dict[str, str]:
     """
     Reject a DHW priority that cannot function with the configured entities.
@@ -611,6 +616,7 @@ class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.ConfigFlowResult:
         """Handle a flow initialized by the user."""
         errors: dict[str, str] = {}
+        entered: dict[str, Any] = user_input or {}
 
         if user_input is not None:
             errors = validate_dhw_priority(user_input)
@@ -651,23 +657,39 @@ class UFHControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_NAME): selector.TextSelector(
+                    vol.Required(
+                        CONF_NAME, description=_suggest(entered, CONF_NAME)
+                    ): selector.TextSelector(
                         selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
                     ),
-                    vol.Optional(CONF_PUMP_REQUEST_ENTITY): selector.EntitySelector(
+                    vol.Optional(
+                        CONF_PUMP_REQUEST_ENTITY,
+                        description=_suggest(entered, CONF_PUMP_REQUEST_ENTITY),
+                    ): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="switch")
                     ),
-                    vol.Optional(CONF_HEAT_REQUEST_ENTITY): selector.EntitySelector(
+                    vol.Optional(
+                        CONF_HEAT_REQUEST_ENTITY,
+                        description=_suggest(entered, CONF_HEAT_REQUEST_ENTITY),
+                    ): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="switch")
                     ),
-                    vol.Optional(CONF_DHW_ACTIVE_ENTITY): selector.EntitySelector(
+                    vol.Optional(
+                        CONF_DHW_ACTIVE_ENTITY,
+                        description=_suggest(entered, CONF_DHW_ACTIVE_ENTITY),
+                    ): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="binary_sensor")
                     ),
                     vol.Required(
                         CONF_DHW_PRIORITY,
-                        default=DEFAULT_DHW_PRIORITY.value,
+                        default=entered.get(
+                            CONF_DHW_PRIORITY, DEFAULT_DHW_PRIORITY.value
+                        ),
                     ): get_dhw_priority_selector(),
-                    vol.Optional(CONF_SUMMER_MODE_ENTITY): selector.EntitySelector(
+                    vol.Optional(
+                        CONF_SUMMER_MODE_ENTITY,
+                        description=_suggest(entered, CONF_SUMMER_MODE_ENTITY),
+                    ): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="select")
                     ),
                 }

--- a/custom_components/ufh_controller/config_flow.py
+++ b/custom_components/ufh_controller/config_flow.py
@@ -734,8 +734,10 @@ class UFHControllerOptionsFlowHandler(config_entries.OptionsFlow):
             )
             return self.async_create_entry(title="", data={})
 
-        # Redisplay the rejected input rather than discarding what was typed
-        current_data = {**self.config_entry.data, **(user_input or {})}
+        # Redisplay the rejected input verbatim. Merging over stored data would
+        # reinstate a field the user cleared, since a cleared optional selector
+        # is absent from user_input rather than present and empty.
+        current_data = user_input if user_input is not None else self.config_entry.data
 
         return self.async_show_form(
             step_id="control_entities",

--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -53,6 +53,26 @@ class SummerMode(StrEnum):
     SUMMER = "summer"
 
 
+class DHWPriority(StrEnum):
+    """
+    Domestic hot water priority levels.
+
+    Controls how the heating circuits behave while the heat source is charging
+    the DHW cylinder. Naming follows established boiler control terminology
+    (Vorrangschaltung):
+
+    - PARALLEL: No restriction, heating and DHW run concurrently.
+    - PARTIAL: Circuits already open stay open, closed circuits cannot start.
+    - ABSOLUTE: All circuits are actively closed for the duration of DHW plus a
+      recovery period. Required on systems where DHW charging raises the flow
+      temperature above what the floor construction tolerates.
+    """
+
+    PARALLEL = "parallel"
+    PARTIAL = "partial"
+    ABSOLUTE = "absolute"
+
+
 class ControllerStatus(StrEnum):
     """Controller operational status for error tracking."""
 
@@ -116,6 +136,7 @@ class TimingDefaults(TypedDict):
     window_block_time: int
     controller_loop_interval: int
     flush_duration: int
+    dhw_recovery_time: int
 
 
 class PIDDefaults(TypedDict):
@@ -157,7 +178,11 @@ DEFAULT_TIMING: TimingDefaults = {
     "window_block_time": 600,  # 10 minutes - block if window open this long
     "controller_loop_interval": 60,  # PID update interval
     "flush_duration": 480,  # 8 minutes - flush duration after DHW ends
+    "dhw_recovery_time": 300,  # 5 minutes - hold-off after DHW under absolute priority
 }
+
+# Default DHW priority level (matches the historical soft-gate behaviour)
+DEFAULT_DHW_PRIORITY = DHWPriority.PARTIAL
 
 
 @dataclass
@@ -176,6 +201,7 @@ class TimingConfig:
     window_block_time: int = DEFAULT_TIMING["window_block_time"]
     controller_loop_interval: int = DEFAULT_TIMING["controller_loop_interval"]
     flush_duration: int = DEFAULT_TIMING["flush_duration"]
+    dhw_recovery_time: int = DEFAULT_TIMING["dhw_recovery_time"]
 
 
 # Default PID controller parameters

--- a/custom_components/ufh_controller/const.py
+++ b/custom_components/ufh_controller/const.py
@@ -264,6 +264,7 @@ UI_TIMING_CLOSING_WARNING = {"min": 60, "max": 600, "step": 30}
 UI_TIMING_WINDOW_BLOCK_TIME = {"min": 0, "max": 3600, "step": 60}
 UI_TIMING_CONTROLLER_LOOP_INTERVAL = {"min": 10, "max": 300, "step": 5}
 UI_TIMING_FLUSH_DURATION = {"min": 0, "max": 1800, "step": 60}  # 0-30 minutes
+UI_TIMING_DHW_RECOVERY_TIME = {"min": 0, "max": 3600, "step": 60}  # 0-60 minutes
 
 # UI validation constraints for setpoint parameters
 UI_SETPOINT_MIN = {"min": 5.0, "max": 30.0, "step": 0.1}

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -79,6 +79,17 @@ STORAGE_VERSION = 3
 STORAGE_KEY = "ufh_controller"
 
 
+def _isoformat(value: datetime | None) -> str | None:
+    """
+    Render a timestamp for the state dict.
+
+    The dict doubles as the Store payload and as the input to
+    async_reload_config, which passes it back in memory. Storing an ISO string
+    rather than a datetime makes both paths round-trip identically.
+    """
+    return value.isoformat() if value is not None else None
+
+
 def _parse_dhw_priority(value: Any) -> DHWPriority:
     """
     Parse a stored DHW priority, falling back to the default.
@@ -1141,13 +1152,8 @@ class UFHControllerDataUpdateCoordinator(
                 "dhw_priority": self._controller.state.dhw_priority.value,
                 "dhw_sensor_available": self._controller.state.dhw_sensor_available,
                 "dhw_block": self._controller.state.dhw_block,
-                # ISO string so the in-place reload path round-trips like storage
-                "dhw_block_until": (
-                    self._controller.state.dhw_block_until.isoformat()
-                    if self._controller.state.dhw_block_until is not None
-                    else None
-                ),
-                "flush_until": self._controller.state.flush_until,
+                "dhw_block_until": _isoformat(self._controller.state.dhw_block_until),
+                "flush_until": _isoformat(self._controller.state.flush_until),
                 "flush_request": self._controller.state.flush_request,
                 "pump_request": self._controller.state.pump_request,
                 "heat_request": self._controller.state.heat_request,
@@ -1217,26 +1223,23 @@ class UFHControllerDataUpdateCoordinator(
 
     def _restore_dhw_state(self, controller_data: dict[str, Any]) -> None:
         """
-        Restore the DHW block and its recovery deadline.
+        Restore the DHW deadlines, and only the deadlines.
 
-        The hold-off is armed only on the DHW ON->OFF edge, and a restart or an
-        in-place config reload destroys the controller that saw it. Without
-        this the deadline is lost and circuits reopen early into a primary that
-        is still at cylinder temperature.
+        Both are armed on the DHW ON->OFF edge, and a restart or an in-place
+        config reload destroys the controller that saw that edge. Losing them
+        reopens circuits early into a primary still at cylinder temperature,
+        so they cannot be reconstructed and must be persisted.
 
-        dhw_active is restored so the edge detector has the right prior state,
-        but the live sensor is re-read on the next cycle and overrides it. An
-        already-expired deadline simply lapses on the first recompute.
+        Everything else is derived and is recomputed from live inputs on the
+        first cycle. Restoring dhw_active would synthesise a false end-of-charge
+        when a mid-charge save meets a sensor that now reads off; restoring
+        dhw_block would strand a stale block forever, because the only code
+        that recomputes it is skipped when no DHW sensor is configured.
         """
-        if "dhw_active" in controller_data:
-            self._controller.state.dhw_active = bool(controller_data["dhw_active"])
-
-        if "dhw_block" in controller_data:
-            self._controller.state.dhw_block = bool(controller_data["dhw_block"])
-
-        if ts := controller_data.get("dhw_block_until"):
-            with contextlib.suppress(ValueError, TypeError):
-                self._controller.state.dhw_block_until = datetime.fromisoformat(ts)
+        for key in ("dhw_block_until", "flush_until"):
+            if ts := controller_data.get(key):
+                with contextlib.suppress(ValueError, TypeError):
+                    setattr(self._controller.state, key, datetime.fromisoformat(ts))
 
     def _restore_controller_state(self, controller_data: dict[str, Any]) -> None:
         """Restore controller-level state from V2 storage format."""

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -1121,7 +1121,12 @@ class UFHControllerDataUpdateCoordinator(
                 "dhw_priority": self._controller.state.dhw_priority.value,
                 "dhw_sensor_available": self._controller.state.dhw_sensor_available,
                 "dhw_block": self._controller.state.dhw_block,
-                "dhw_block_until": self._controller.state.dhw_block_until,
+                # ISO string so the in-place reload path round-trips like storage
+                "dhw_block_until": (
+                    self._controller.state.dhw_block_until.isoformat()
+                    if self._controller.state.dhw_block_until is not None
+                    else None
+                ),
                 "flush_until": self._controller.state.flush_until,
                 "flush_request": self._controller.state.flush_request,
                 "pump_request": self._controller.state.pump_request,
@@ -1190,6 +1195,29 @@ class UFHControllerDataUpdateCoordinator(
         self._controller.state.flush_enabled = enabled
         await self.async_request_refresh()
 
+    def _restore_dhw_state(self, controller_data: dict[str, Any]) -> None:
+        """
+        Restore the DHW block and its recovery deadline.
+
+        The hold-off is armed only on the DHW ON->OFF edge, and a restart or an
+        in-place config reload destroys the controller that saw it. Without
+        this the deadline is lost and circuits reopen early into a primary that
+        is still at cylinder temperature.
+
+        dhw_active is restored so the edge detector has the right prior state,
+        but the live sensor is re-read on the next cycle and overrides it. An
+        already-expired deadline simply lapses on the first recompute.
+        """
+        if "dhw_active" in controller_data:
+            self._controller.state.dhw_active = bool(controller_data["dhw_active"])
+
+        if "dhw_block" in controller_data:
+            self._controller.state.dhw_block = bool(controller_data["dhw_block"])
+
+        if ts := controller_data.get("dhw_block_until"):
+            with contextlib.suppress(ValueError, TypeError):
+                self._controller.state.dhw_block_until = datetime.fromisoformat(ts)
+
     def _restore_controller_state(self, controller_data: dict[str, Any]) -> None:
         """Restore controller-level state from V2 storage format."""
         if "mode" in controller_data:
@@ -1204,6 +1232,8 @@ class UFHControllerDataUpdateCoordinator(
             self._controller.state.supply_target_temp = controller_data[
                 "supply_target_temp"
             ]
+
+        self._restore_dhw_state(controller_data)
 
         if ts := controller_data.get("last_force_update"):
             with contextlib.suppress(ValueError, TypeError):

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from .config_flow import (
     CONF_DHW_ACTIVE_ENTITY,
+    CONF_DHW_PRIORITY,
     CONF_HEAT_REQUEST_ENTITY,
     CONF_OUTDOOR_TEMP_ENTITY,
     CONF_PUMP_REQUEST_ENTITY,
@@ -36,6 +37,7 @@ from homeassistant.helpers.update_coordinator import TimestampDataUpdateCoordina
 from sqlalchemy.exc import SQLAlchemyError
 
 from .const import (
+    DEFAULT_DHW_PRIORITY,
     DEFAULT_OUTDOOR_TEMP_COLD,
     DEFAULT_OUTDOOR_TEMP_WARM,
     DEFAULT_PID,
@@ -51,6 +53,7 @@ from .const import (
     SUBENTRY_TYPE_CONTROLLER,
     SUBENTRY_TYPE_ZONE,
     ControllerStatus,
+    DHWPriority,
     OperationMode,
     SummerMode,
     TimingConfig,
@@ -225,6 +228,9 @@ class UFHControllerDataUpdateCoordinator(
             flush_duration=timing_opts.get(
                 "flush_duration", DEFAULT_TIMING["flush_duration"]
             ),
+            dhw_recovery_time=timing_opts.get(
+                "dhw_recovery_time", DEFAULT_TIMING["dhw_recovery_time"]
+            ),
         )
 
         # Build zones from subentries
@@ -283,6 +289,9 @@ class UFHControllerDataUpdateCoordinator(
             pump_request_entity=data.get(CONF_PUMP_REQUEST_ENTITY),
             heat_request_entity=data.get(CONF_HEAT_REQUEST_ENTITY),
             dhw_active_entity=data.get(CONF_DHW_ACTIVE_ENTITY),
+            dhw_priority=DHWPriority(
+                data.get(CONF_DHW_PRIORITY) or DEFAULT_DHW_PRIORITY
+            ),
             summer_mode_entity=data.get(CONF_SUMMER_MODE_ENTITY),
             supply_temp_entity=data.get(CONF_SUPPLY_TEMP_ENTITY),
             outdoor_temp_entity=data.get(CONF_OUTDOOR_TEMP_ENTITY),
@@ -1097,6 +1106,9 @@ class UFHControllerDataUpdateCoordinator(
                 "zones_fail_safe": zones_fail_safe,
                 "flush_enabled": self._controller.state.flush_enabled,
                 "dhw_active": self._controller.state.dhw_active,
+                "dhw_priority": self._controller.config.dhw_priority.value,
+                "dhw_block": self._controller.state.dhw_block,
+                "dhw_block_until": self._controller.state.dhw_block_until,
                 "flush_until": self._controller.state.flush_until,
                 "flush_request": self._controller.state.flush_request,
                 "pump_request": self._controller.state.pump_request,

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -23,6 +23,7 @@ from homeassistant.components.select import SERVICE_SELECT_OPTION
 from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     Platform,
@@ -60,7 +61,7 @@ from .const import (
     ValveState,
     ZoneStatus,
 )
-from .core.controller import ControllerConfig, HeatingController
+from .core.controller import ControllerConfig, HeatingController, resolve_dhw_active
 from .core.heating_curve import HeatingCurveConfig
 from .core.history import get_valve_position_window
 from .core.pid import PIDState
@@ -664,9 +665,20 @@ class UFHControllerDataUpdateCoordinator(
             return
 
         state = self.hass.states.get(dhw_entity)
-        current_dhw_active = state is not None and state.state == "on"
+        available = state is not None and state.state not in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        )
+        current_dhw_active = resolve_dhw_active(
+            sensor_available=available,
+            sensor_on=state is not None and state.state == STATE_ON,
+            last_known=self._controller.state.dhw_active,
+            priority=self._controller.config.dhw_priority,
+        )
         self._controller.update_dhw_state(
-            dhw_active=current_dhw_active, now=datetime.now(UTC)
+            dhw_active=current_dhw_active,
+            now=datetime.now(UTC),
+            sensor_available=available,
         )
 
     def _get_supply_temp(self) -> float | None:
@@ -1107,6 +1119,7 @@ class UFHControllerDataUpdateCoordinator(
                 "flush_enabled": self._controller.state.flush_enabled,
                 "dhw_active": self._controller.state.dhw_active,
                 "dhw_priority": self._controller.state.dhw_priority.value,
+                "dhw_sensor_available": self._controller.state.dhw_sensor_available,
                 "dhw_block": self._controller.state.dhw_block,
                 "dhw_block_until": self._controller.state.dhw_block_until,
                 "flush_until": self._controller.state.flush_until,

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -641,7 +641,7 @@ class UFHControllerDataUpdateCoordinator(
                 seconds=self._controller.config.timing.controller_loop_interval
             )
 
-        # If ALL zones are in fail-safe, execute controller-level fail-safe
+        # Controller fail-safe, from all zones failing or a controller-level fault
         if (
             self._controller.status == ControllerStatus.FAIL_SAFE
             and self._controller.mode != OperationMode.OFF

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -1106,7 +1106,7 @@ class UFHControllerDataUpdateCoordinator(
                 "zones_fail_safe": zones_fail_safe,
                 "flush_enabled": self._controller.state.flush_enabled,
                 "dhw_active": self._controller.state.dhw_active,
-                "dhw_priority": self._controller.config.dhw_priority.value,
+                "dhw_priority": self._controller.state.dhw_priority.value,
                 "dhw_block": self._controller.state.dhw_block,
                 "dhw_block_until": self._controller.state.dhw_block_until,
                 "flush_until": self._controller.state.flush_until,

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -61,7 +61,7 @@ from .const import (
     ValveState,
     ZoneStatus,
 )
-from .core.controller import ControllerConfig, HeatingController, resolve_dhw_active
+from .core.controller import ControllerConfig, HeatingController
 from .core.heating_curve import HeatingCurveConfig
 from .core.history import get_valve_position_window
 from .core.pid import PIDState
@@ -700,14 +700,8 @@ class UFHControllerDataUpdateCoordinator(
             STATE_UNAVAILABLE,
             STATE_UNKNOWN,
         )
-        current_dhw_active = resolve_dhw_active(
-            sensor_available=available,
-            sensor_on=state is not None and state.state == STATE_ON,
-            last_known=self._controller.state.dhw_active,
-            priority=self._controller.config.dhw_priority,
-        )
         self._controller.update_dhw_state(
-            dhw_active=current_dhw_active,
+            dhw_active=state is not None and state.state == STATE_ON,
             now=datetime.now(UTC),
             sensor_available=available,
         )

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -79,6 +79,28 @@ STORAGE_VERSION = 3
 STORAGE_KEY = "ufh_controller"
 
 
+def _parse_dhw_priority(value: Any) -> DHWPriority:
+    """
+    Parse a stored DHW priority, falling back to the default.
+
+    Constructing the enum directly raises on any unrecognised value, and that
+    exception propagates out of setup, leaving the integration with no heating
+    control at all rather than a mistuned one. Reachable by downgrading after
+    a new level is added, or by a hand-edited config entry.
+    """
+    if not value:
+        return DEFAULT_DHW_PRIORITY
+    try:
+        return DHWPriority(value)
+    except ValueError:
+        LOGGER.warning(
+            "Unrecognised dhw_priority %r, falling back to %s",
+            value,
+            DEFAULT_DHW_PRIORITY.value,
+        )
+        return DEFAULT_DHW_PRIORITY
+
+
 class UFHControllerStore(Store[dict[str, Any]]):
     """Store with migration support."""
 
@@ -290,9 +312,7 @@ class UFHControllerDataUpdateCoordinator(
             pump_request_entity=data.get(CONF_PUMP_REQUEST_ENTITY),
             heat_request_entity=data.get(CONF_HEAT_REQUEST_ENTITY),
             dhw_active_entity=data.get(CONF_DHW_ACTIVE_ENTITY),
-            dhw_priority=DHWPriority(
-                data.get(CONF_DHW_PRIORITY) or DEFAULT_DHW_PRIORITY
-            ),
+            dhw_priority=_parse_dhw_priority(data.get(CONF_DHW_PRIORITY)),
             summer_mode_entity=data.get(CONF_SUMMER_MODE_ENTITY),
             supply_temp_entity=data.get(CONF_SUPPLY_TEMP_ENTITY),
             outdoor_temp_entity=data.get(CONF_OUTDOOR_TEMP_ENTITY),

--- a/custom_components/ufh_controller/coordinator.py
+++ b/custom_components/ufh_controller/coordinator.py
@@ -1137,6 +1137,7 @@ class UFHControllerDataUpdateCoordinator(
                 "observation_start": self._controller.state.observation_start,
                 "period_elapsed": self._controller.state.period_elapsed,
                 "status": self._controller.status.value,
+                "fail_safe_reason": self._controller.fail_safe_reason,
                 "zones_initializing": zones_initializing,
                 "zones_normal": zones_normal,
                 "zones_degraded": zones_degraded,

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -699,8 +699,10 @@ class HeatingController:
 
         # Detect DHW OFF transition (was on, now off)
         if self._state.dhw_active and not dhw_active:
-            # Safety timer, armed regardless of the flush feature
-            self._state.dhw_block_until = now + timedelta(seconds=recovery)
+            # Safety timer, armed regardless of the flush feature but only
+            # where a block can actually engage
+            if absolute:
+                self._state.dhw_block_until = now + timedelta(seconds=recovery)
 
             flush_duration = self.config.timing.flush_duration
             if flush_duration > 0 and self._state.flush_enabled:

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from custom_components.ufh_controller.const import (
     DEFAULT_CYCLE_MODE_HOURS,
     DEFAULT_DHW_PRIORITY,
+    FAIL_SAFE_TIMEOUT,
     INITIALIZING_TIMEOUT,
     ControllerStatus,
     DHWPriority,
@@ -253,7 +254,7 @@ class HeatingController:
 
         if not zone_statuses:
             self._state.status = ControllerStatus.NORMAL
-            self._apply_dhw_fault_status()
+            self._apply_dhw_fault_status(now)
             return
 
         # Count zones in each state
@@ -289,11 +290,18 @@ class HeatingController:
             # Mix of degraded and fail-safe, but no normal or initializing
             self._state.status = ControllerStatus.DEGRADED
 
-        self._apply_dhw_fault_status()
+        self._apply_dhw_fault_status(now)
 
-    def _apply_dhw_fault_status(self) -> None:
+    def _apply_dhw_fault_status(self, now: datetime) -> None:
         """
         Raise the controller status while the DHW sensor is faulted.
+
+        Two stages, matching how zone failures already escalate. The block
+        applied in update_dhw_state is the protective half and is immediate;
+        this is the reporting half. Escalation to fail-safe is deferred by
+        FAIL_SAFE_TIMEOUT because the valves are already shut, so it adds no
+        protection - it signals a persistent fault and hands the boiler back
+        its own thermostats.
 
         Applied after zone aggregation so it cannot be overwritten, and after
         the INITIALIZING deferral so a sensor that has not loaded yet during
@@ -302,7 +310,10 @@ class HeatingController:
         if not self._state.dhw_sensor_fault:
             return
 
-        if self._state.status != ControllerStatus.FAIL_SAFE:
+        since = self._state.dhw_sensor_fault_since
+        if since is not None and (now - since).total_seconds() > FAIL_SAFE_TIMEOUT:
+            self._state.status = ControllerStatus.FAIL_SAFE
+        elif self._state.status != ControllerStatus.FAIL_SAFE:
             self._state.status = ControllerStatus.DEGRADED
 
     def get_zone_state(self, zone_id: str) -> ZoneState:

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -445,6 +445,12 @@ class HeatingController:
         Uses PID-based quota scheduling for regular zones, then evaluates
         flush circuits based on whether any regular zones are running.
 
+        The heat request is gated on dhw_block because thermal actuators need
+        minutes to close: a circuit still reports flow at the instant DHW
+        asserts, which would otherwise have the controller ask the boiler to
+        fire for space heating mid-charge. Pump request stays flow-driven and
+        decays on its own as the valves close.
+
         Returns raw computed values; the coordinator handles change detection.
         """
         valve_actions: dict[str, ZoneAction] = {}
@@ -483,13 +489,12 @@ class HeatingController:
         # Pump request: any zone with confirmed flow
         pump_request = any(rt.state.flow for rt in self._zones.values())
 
-        # Aggregate heat request from per-zone decisions, gated on pump
+        # Aggregate heat request from per-zone decisions, gated on pump and DHW
         remaining_durations = {
             zone_id: rt.state.remaining_duration
             for zone_id, rt in self._zones.items()
             if rt.state.flow
         }
-        # A closing valve still reports flow, which would otherwise ask for heat
         heat_request = (
             not self._state.dhw_block
             and pump_request
@@ -605,7 +610,7 @@ class HeatingController:
 
             flush_duration = self.config.timing.flush_duration
             if flush_duration > 0 and self._state.flush_enabled:
-                # Absolute priority defers the flush window past the hold-off
+                # Flush opens after the hold-off under absolute, at once otherwise
                 offset = recovery if absolute else 0
                 self._state.flush_until = now + timedelta(
                     seconds=offset + flush_duration

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -487,11 +487,13 @@ class HeatingController:
         Uses PID-based quota scheduling for regular zones, then evaluates
         flush circuits based on whether any regular zones are running.
 
-        The heat request is gated on dhw_block because thermal actuators need
-        minutes to close: a circuit still reports flow at the instant DHW
-        asserts, which would otherwise have the controller ask the boiler to
-        fire for space heating mid-charge. Pump request stays flow-driven and
-        decays on its own as the valves close.
+        Both the heat and pump requests are gated on dhw_block. Thermal
+        actuators need minutes to close, so a circuit still reports flow at the
+        instant DHW asserts; without the gate the controller would ask the
+        boiler to fire mid-charge and keep an independent circulation pump
+        pushing cylinder-temperature water through the closing circuit. Since
+        pump_request_entity drives a pump the controller owns, stopping it is
+        the one part of that exposure window software can actually shorten.
 
         Returns raw computed values; the coordinator handles change detection.
         """
@@ -528,8 +530,10 @@ class HeatingController:
                     flush_request=flush_request,
                 )
 
-        # Pump request: any zone with confirmed flow
-        pump_request = any(rt.state.flow for rt in self._zones.values())
+        # Pump request: any zone with confirmed flow, unless DHW holds us closed
+        pump_request = not self._state.dhw_block and any(
+            rt.state.flow for rt in self._zones.values()
+        )
 
         # Aggregate heat request from per-zone decisions, gated on pump and DHW
         remaining_durations = {

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -91,10 +91,11 @@ class ControllerActions:
     flush_request: bool = False
 
 
-def compute_flush_request(
+def compute_flush_request(  # noqa: PLR0913
     *,
     flush_enabled: bool,
     dhw_active: bool,
+    dhw_block: bool,
     flush_until: datetime | None,
     any_regular_on: bool,
     now: datetime,
@@ -105,12 +106,19 @@ def compute_flush_request(
     Flush circuits activate when:
     - flush_enabled is True (user has enabled the feature)
     - DHW is NOT currently active
+    - Absolute DHW priority is NOT holding circuits closed
     - Post-DHW timer is active
     - No regular circuits are currently ON
+
+    Latent heat capture and absolute DHW priority are opposing answers to the
+    same question: what to do with the water left in the primary when DHW
+    finishes. The block wins, which makes the two mutually exclusive by
+    construction rather than merely by evaluation order.
 
     Args:
         flush_enabled: User toggle for flush feature.
         dhw_active: Whether DHW is currently heating.
+        dhw_block: Whether absolute DHW priority is holding circuits closed.
         flush_until: Post-DHW timer expiration, or None.
         any_regular_on: Whether any regular zones have valves ON.
         now: Current time for timer comparison.
@@ -122,7 +130,7 @@ def compute_flush_request(
     if not flush_enabled:
         return False
 
-    if dhw_active:
+    if dhw_active or dhw_block:
         return False
 
     if flush_until is None or now >= flush_until:
@@ -451,6 +459,7 @@ class HeatingController:
         flush_request = compute_flush_request(
             flush_enabled=self._state.flush_enabled,
             dhw_active=self._state.dhw_active,
+            dhw_block=self._state.dhw_block,
             flush_until=self._state.flush_until,
             any_regular_on=any_regular_on,
             now=now,

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -489,7 +489,7 @@ class HeatingController:
             for zone_id, rt in self._zones.items()
             if rt.state.flow
         }
-        # Valves take minutes to close, so drop the heat request explicitly
+        # A closing valve still reports flow, which would otherwise ask for heat
         heat_request = (
             not self._state.dhw_block
             and pump_request

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -360,8 +360,13 @@ class HeatingController:
         """
         Flush mode - all valves open, circulation only (no boiler firing).
 
-        Permanently not heating: heat_request=False.
+        Permanently not heating: heat_request=False. Suspended while absolute
+        DHW priority holds the circuits closed; the mode itself is retained and
+        resumes once the block clears.
         """
+        if self._state.dhw_block:
+            return self._evaluate_all_off_mode()
+
         valve_actions = {
             zid: (
                 ZoneAction.STAY_ON
@@ -384,8 +389,13 @@ class HeatingController:
         Hour 0: all closed (rest hour)
         Hours 1-7: zones open sequentially
 
-        Permanently not heating: heat_request=False.
+        Permanently not heating: heat_request=False. Suspended while absolute
+        DHW priority holds the circuits closed; the rotation is retained and
+        resumes once the block clears.
         """
+        if self._state.dhw_block:
+            return self._evaluate_all_off_mode()
+
         cycle_hour = now.hour % DEFAULT_CYCLE_MODE_HOURS
         zone_ids = list(self._zones.keys())
 

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -672,13 +672,16 @@ class HeatingController:
         if dhw_active and not self._state.dhw_active:
             self._state.flush_until = None
 
+        # Drop an expired deadline so it stops being reported as pending
+        if (
+            self._state.dhw_block_until is not None
+            and now >= self._state.dhw_block_until
+        ):
+            self._state.dhw_block_until = None
+
         self._state.dhw_active = dhw_active
         self._state.dhw_block = absolute and (
-            dhw_active
-            or (
-                self._state.dhw_block_until is not None
-                and now < self._state.dhw_block_until
-            )
+            dhw_active or self._state.dhw_block_until is not None
         )
 
     def handle_observation_period_transition(self, now: datetime) -> bool:

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -51,6 +51,8 @@ class ControllerState:
     dhw_active: bool = False
     dhw_priority: DHWPriority = DEFAULT_DHW_PRIORITY
     dhw_sensor_available: bool = True
+    dhw_sensor_fault: bool = False
+    dhw_sensor_fault_since: datetime | None = None
     dhw_block: bool = False
     dhw_block_until: datetime | None = None
     flush_until: datetime | None = None
@@ -93,45 +95,32 @@ class ControllerActions:
     flush_request: bool = False
 
 
-def resolve_dhw_active(
+def is_dhw_sensor_faulted(
     *,
     sensor_available: bool,
-    sensor_on: bool,
-    last_known: bool,
     priority: DHWPriority,
 ) -> bool:
     """
-    Resolve DHW active state, tolerating a sensor that has dropped out.
+    Decide whether an unreadable DHW sensor is a fault.
 
-    A sensor reading unavailable or unknown carries no information. Treating
-    that as "off" synthesises an ON->OFF edge, which under absolute priority
-    arms the recovery hold-off and then reopens every circuit while the heat
-    source may still be charging the cylinder.
+    A sensor reading unavailable or unknown carries no information at all.
+    Under absolute priority that is not a state to be inferred: the setting
+    exists because we must be certain DHW is not charging before opening a
+    circuit, and neither "assume off" nor "assume the last known value" can
+    provide that certainty. It is treated as a fault instead.
 
-    Absolute priority therefore holds the last known state until the sensor
-    returns. Choosing it is a statement that over-temperature flow is a
-    hardware hazard, so uncertainty resolves towards keeping circuits closed,
-    consistent with how zone sensor loss already forces valves shut. Parallel
-    and partial keep the historical fail-open behaviour, where the cost is
-    comfort rather than damage.
+    Parallel and partial keep the historical behaviour of resolving an
+    unreadable sensor to "off", where the cost is comfort rather than damage.
 
     Args:
         sensor_available: Whether the DHW sensor reported a usable state.
-        sensor_on: Whether that state was "on" (meaningless if unavailable).
-        last_known: Previously resolved DHW active state.
         priority: Configured DHW priority level.
 
     Returns:
-        The DHW active state to act on this cycle.
+        True if the unreadable sensor should be treated as a fault.
 
     """
-    if sensor_available:
-        return sensor_on
-
-    if priority == DHWPriority.ABSOLUTE:
-        return last_known
-
-    return False
+    return not sensor_available and priority == DHWPriority.ABSOLUTE
 
 
 def compute_flush_request(  # noqa: PLR0913
@@ -264,6 +253,7 @@ class HeatingController:
 
         if not zone_statuses:
             self._state.status = ControllerStatus.NORMAL
+            self._apply_dhw_fault_status()
             return
 
         # Count zones in each state
@@ -297,6 +287,22 @@ class HeatingController:
             self._state.status = ControllerStatus.FAIL_SAFE
         else:
             # Mix of degraded and fail-safe, but no normal or initializing
+            self._state.status = ControllerStatus.DEGRADED
+
+        self._apply_dhw_fault_status()
+
+    def _apply_dhw_fault_status(self) -> None:
+        """
+        Raise the controller status while the DHW sensor is faulted.
+
+        Applied after zone aggregation so it cannot be overwritten, and after
+        the INITIALIZING deferral so a sensor that has not loaded yet during
+        startup does not trip it.
+        """
+        if not self._state.dhw_sensor_fault:
+            return
+
+        if self._state.status != ControllerStatus.FAIL_SAFE:
             self._state.status = ControllerStatus.DEGRADED
 
     def get_zone_state(self, zone_id: str) -> ZoneState:
@@ -629,6 +635,22 @@ class HeatingController:
 
         return SummerMode.WINTER if heat_request else SummerMode.SUMMER
 
+    def _apply_dhw_sensor_fault(self, now: datetime) -> None:
+        """
+        Hold everything still while the DHW sensor cannot be read.
+
+        No edge detection and no timer changes: an unreadable sensor gives no
+        information to detect edges from, and inventing one would either arm
+        the recovery hold-off from a charge that has not ended or release a
+        hold-off that should still be running. Circuits are blocked outright
+        instead, and the fault clock starts so a sustained outage can escalate.
+        """
+        self._state.dhw_sensor_available = False
+        self._state.dhw_block = True
+        if not self._state.dhw_sensor_fault:
+            self._state.dhw_sensor_fault = True
+            self._state.dhw_sensor_fault_since = now
+
     def update_dhw_state(
         self, *, dhw_active: bool, now: datetime, sensor_available: bool = True
     ) -> None:
@@ -651,9 +673,18 @@ class HeatingController:
 
         """
         self._state.dhw_priority = self.config.dhw_priority
-        self._state.dhw_sensor_available = sensor_available
         absolute = self.config.dhw_priority == DHWPriority.ABSOLUTE
         recovery = self.config.timing.dhw_recovery_time
+
+        if is_dhw_sensor_faulted(
+            sensor_available=sensor_available, priority=self.config.dhw_priority
+        ):
+            self._apply_dhw_sensor_fault(now)
+            return
+
+        self._state.dhw_sensor_available = sensor_available
+        self._state.dhw_sensor_fault = False
+        self._state.dhw_sensor_fault_since = None
 
         # Detect DHW OFF transition (was on, now off)
         if self._state.dhw_active and not dhw_active:

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -49,6 +49,7 @@ class ControllerState:
     heat_request: bool | None = None
     flush_enabled: bool = False
     dhw_active: bool = False
+    dhw_priority: DHWPriority = DEFAULT_DHW_PRIORITY
     dhw_block: bool = False
     dhw_block_until: datetime | None = None
     flush_until: datetime | None = None
@@ -163,7 +164,11 @@ class HeatingController:
 
         """
         self.config = config
-        self._state = ControllerState(started_at=started_at, mode=OperationMode.HEAT)
+        self._state = ControllerState(
+            started_at=started_at,
+            mode=OperationMode.HEAT,
+            dhw_priority=config.dhw_priority,
+        )
         self._zones: dict[str, ZoneRuntime] = {}
 
         # Initialize zones from config
@@ -484,9 +489,14 @@ class HeatingController:
             for zone_id, rt in self._zones.items()
             if rt.state.flow
         }
-        heat_request = pump_request and any(
-            rd > self.config.timing.closing_warning_duration
-            for rd in remaining_durations.values()
+        # Valves take minutes to close, so drop the heat request explicitly
+        heat_request = (
+            not self._state.dhw_block
+            and pump_request
+            and any(
+                rd > self.config.timing.closing_warning_duration
+                for rd in remaining_durations.values()
+            )
         )
 
         return ControllerActions(
@@ -584,6 +594,7 @@ class HeatingController:
             now: Current time for timer calculation.
 
         """
+        self._state.dhw_priority = self.config.dhw_priority
         absolute = self.config.dhw_priority == DHWPriority.ABSOLUTE
         recovery = self.config.timing.dhw_recovery_time
 

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -12,8 +12,10 @@ from datetime import datetime, timedelta
 
 from custom_components.ufh_controller.const import (
     DEFAULT_CYCLE_MODE_HOURS,
+    DEFAULT_DHW_PRIORITY,
     INITIALIZING_TIMEOUT,
     ControllerStatus,
+    DHWPriority,
     OperationMode,
     SummerMode,
     TimingConfig,
@@ -47,6 +49,8 @@ class ControllerState:
     heat_request: bool | None = None
     flush_enabled: bool = False
     dhw_active: bool = False
+    dhw_block: bool = False
+    dhw_block_until: datetime | None = None
     flush_until: datetime | None = None
     flush_request: bool = False
     zones: dict[str, ZoneState] = field(default_factory=dict)
@@ -64,6 +68,7 @@ class ControllerConfig:
     pump_request_entity: str | None = None
     heat_request_entity: str | None = None
     dhw_active_entity: str | None = None
+    dhw_priority: DHWPriority = DEFAULT_DHW_PRIORITY
     summer_mode_entity: str | None = None
     supply_temp_entity: str | None = None
     outdoor_temp_entity: str | None = None
@@ -546,28 +551,48 @@ class HeatingController:
 
     def update_dhw_state(self, *, dhw_active: bool, now: datetime) -> None:
         """
-        Update DHW state and manage post-DHW flush timer.
+        Update DHW state and manage the block and post-DHW flush timers.
 
         Detects transitions:
-        - ON→OFF: starts post-flush timer if flush enabled and duration > 0
+        - ON→OFF: arms the recovery hold-off and starts the post-flush timer if
+          flush enabled and duration > 0
         - OFF→ON: clears flush_until timer
+
+        Recomputes dhw_block on every call so the hold-off expires on time.
 
         Args:
             dhw_active: Current DHW active state.
-            now: Current time for flush timer calculation.
+            now: Current time for timer calculation.
 
         """
+        absolute = self.config.dhw_priority == DHWPriority.ABSOLUTE
+        recovery = self.config.timing.dhw_recovery_time
+
         # Detect DHW OFF transition (was on, now off)
         if self._state.dhw_active and not dhw_active:
+            # Safety timer, armed regardless of the flush feature
+            self._state.dhw_block_until = now + timedelta(seconds=recovery)
+
             flush_duration = self.config.timing.flush_duration
             if flush_duration > 0 and self._state.flush_enabled:
-                self._state.flush_until = now + timedelta(seconds=flush_duration)
+                # Absolute priority defers the flush window past the hold-off
+                offset = recovery if absolute else 0
+                self._state.flush_until = now + timedelta(
+                    seconds=offset + flush_duration
+                )
 
         # Clear flush_until when DHW starts
         if dhw_active and not self._state.dhw_active:
             self._state.flush_until = None
 
         self._state.dhw_active = dhw_active
+        self._state.dhw_block = absolute and (
+            dhw_active
+            or (
+                self._state.dhw_block_until is not None
+                and now < self._state.dhw_block_until
+            )
+        )
 
     def handle_observation_period_transition(self, now: datetime) -> bool:
         """

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -764,6 +764,18 @@ class HeatingController:
         return new_period
 
     @property
+    def fail_safe_reason(self) -> str | None:
+        """Explain a degraded or fail-safe status, or None when normal."""
+        if self._state.status not in (
+            ControllerStatus.DEGRADED,
+            ControllerStatus.FAIL_SAFE,
+        ):
+            return None
+        if self._state.dhw_sensor_fault:
+            return "dhw_sensor_unavailable"
+        return "zone_failures"
+
+    @property
     def any_zone_in_fail_safe(self) -> bool:
         """Check if any zone is in fail-safe mode."""
         return any(

--- a/custom_components/ufh_controller/core/controller.py
+++ b/custom_components/ufh_controller/core/controller.py
@@ -50,6 +50,7 @@ class ControllerState:
     flush_enabled: bool = False
     dhw_active: bool = False
     dhw_priority: DHWPriority = DEFAULT_DHW_PRIORITY
+    dhw_sensor_available: bool = True
     dhw_block: bool = False
     dhw_block_until: datetime | None = None
     flush_until: datetime | None = None
@@ -90,6 +91,47 @@ class ControllerActions:
     pump_request: bool | None = None
     heat_request: bool | None = None
     flush_request: bool = False
+
+
+def resolve_dhw_active(
+    *,
+    sensor_available: bool,
+    sensor_on: bool,
+    last_known: bool,
+    priority: DHWPriority,
+) -> bool:
+    """
+    Resolve DHW active state, tolerating a sensor that has dropped out.
+
+    A sensor reading unavailable or unknown carries no information. Treating
+    that as "off" synthesises an ON->OFF edge, which under absolute priority
+    arms the recovery hold-off and then reopens every circuit while the heat
+    source may still be charging the cylinder.
+
+    Absolute priority therefore holds the last known state until the sensor
+    returns. Choosing it is a statement that over-temperature flow is a
+    hardware hazard, so uncertainty resolves towards keeping circuits closed,
+    consistent with how zone sensor loss already forces valves shut. Parallel
+    and partial keep the historical fail-open behaviour, where the cost is
+    comfort rather than damage.
+
+    Args:
+        sensor_available: Whether the DHW sensor reported a usable state.
+        sensor_on: Whether that state was "on" (meaningless if unavailable).
+        last_known: Previously resolved DHW active state.
+        priority: Configured DHW priority level.
+
+    Returns:
+        The DHW active state to act on this cycle.
+
+    """
+    if sensor_available:
+        return sensor_on
+
+    if priority == DHWPriority.ABSOLUTE:
+        return last_known
+
+    return False
 
 
 def compute_flush_request(  # noqa: PLR0913
@@ -583,7 +625,9 @@ class HeatingController:
 
         return SummerMode.WINTER if heat_request else SummerMode.SUMMER
 
-    def update_dhw_state(self, *, dhw_active: bool, now: datetime) -> None:
+    def update_dhw_state(
+        self, *, dhw_active: bool, now: datetime, sensor_available: bool = True
+    ) -> None:
         """
         Update DHW state and manage the block and post-DHW flush timers.
 
@@ -595,11 +639,15 @@ class HeatingController:
         Recomputes dhw_block on every call so the hold-off expires on time.
 
         Args:
-            dhw_active: Current DHW active state.
+            dhw_active: Current DHW active state, already resolved against
+                sensor availability by resolve_dhw_active.
             now: Current time for timer calculation.
+            sensor_available: Whether the DHW sensor reported a usable state,
+                recorded for diagnostics.
 
         """
         self._state.dhw_priority = self.config.dhw_priority
+        self._state.dhw_sensor_available = sensor_available
         absolute = self.config.dhw_priority == DHWPriority.ABSOLUTE
         recovery = self.config.timing.dhw_recovery_time
 

--- a/custom_components/ufh_controller/core/zone.py
+++ b/custom_components/ufh_controller/core/zone.py
@@ -20,6 +20,7 @@ from custom_components.ufh_controller.const import (
     DEFAULT_VALVE_OPEN_THRESHOLD,
     FAIL_SAFE_TIMEOUT,
     INITIALIZING_TIMEOUT,
+    DHWPriority,
     OperationMode,
     TimingConfig,
     ValveState,
@@ -555,7 +556,11 @@ def evaluate_zone(  # noqa: PLR0911
         if estimated_runtime < timing.min_run_time:
             return ZoneAction.STAY_OFF if valve_off else ZoneAction.TURN_OFF
 
-        if controller.dhw_active and zone.circuit_type == CircuitType.REGULAR:
+        if (
+            controller.dhw_active
+            and controller.dhw_priority == DHWPriority.PARTIAL
+            and zone.circuit_type == CircuitType.REGULAR
+        ):
             # Wait for DHW heating to finish
             return ZoneAction.STAY_OFF if valve_off else ZoneAction.TURN_OFF
 

--- a/custom_components/ufh_controller/core/zone.py
+++ b/custom_components/ufh_controller/core/zone.py
@@ -493,6 +493,8 @@ def evaluate_zone(  # noqa: PLR0911
 
     Implements quota-based scheduling and flush circuit priority.
     Note: Window blocking is handled via PID pause, not valve control.
+    Absolute DHW priority (controller.dhw_block) does close valves, because
+    the hazard it guards against is hydraulic rather than thermal.
 
     Args:
         zone: Current zone state.
@@ -509,6 +511,10 @@ def evaluate_zone(  # noqa: PLR0911
 
     # Zone disabled - always off
     if not zone.enabled:
+        return ZoneAction.STAY_OFF if valve_off else ZoneAction.TURN_OFF
+
+    # Absolute DHW priority - all circuit types closed, overrides every other path
+    if controller.dhw_block:
         return ZoneAction.STAY_OFF if valve_off else ZoneAction.TURN_OFF
 
     # Flush circuit activation

--- a/custom_components/ufh_controller/strings.json
+++ b/custom_components/ufh_controller/strings.json
@@ -297,6 +297,9 @@
           "dhw_active": {
             "name": "DHW Active"
           },
+          "dhw_sensor_available": {
+            "name": "DHW Sensor Available"
+          },
           "dhw_block_until": {
             "name": "Block Until"
           }

--- a/custom_components/ufh_controller/strings.json
+++ b/custom_components/ufh_controller/strings.json
@@ -9,7 +9,11 @@
           "pump_request_entity": "Pump request switch",
           "heat_request_entity": "Heat request switch",
           "dhw_active_entity": "DHW active sensor",
+          "dhw_priority": "DHW priority",
           "summer_mode_entity": "Summer mode select"
+        },
+        "data_description": {
+          "dhw_priority": "How heating circuits behave while the heat source is charging domestic hot water. Choose Absolute if DHW charging raises the flow temperature above what your floor construction tolerates and no mixing valve or diverter protects the manifold."
         }
       }
     },
@@ -33,7 +37,11 @@
           "pump_request_entity": "Pump request switch",
           "heat_request_entity": "Heat request switch",
           "dhw_active_entity": "DHW active sensor",
+          "dhw_priority": "DHW priority",
           "summer_mode_entity": "Summer mode select"
+        },
+        "data_description": {
+          "dhw_priority": "How heating circuits behave while the heat source is charging domestic hot water. Choose Absolute if DHW charging raises the flow temperature above what your floor construction tolerates and no mixing valve or diverter protects the manifold."
         }
       },
       "timing": {
@@ -46,7 +54,11 @@
           "closing_warning_duration": "Closing warning duration",
           "window_block_time": "Window block time",
           "controller_loop_interval": "Controller loop interval",
-          "flush_duration": "Flush duration after DHW"
+          "flush_duration": "Flush duration after DHW",
+          "dhw_recovery_time": "DHW recovery time"
+        },
+        "data_description": {
+          "dhw_recovery_time": "Under absolute priority, how long circuits stay closed after DHW finishes so the primary flow temperature can fall back to heating levels. Also delays the post-DHW flush window by the same amount."
         }
       },
       "heat_accounting": {
@@ -126,7 +138,11 @@
             "closing_warning_duration": "Closing warning duration",
             "window_block_time": "Window block time",
             "controller_loop_interval": "Controller loop interval",
-            "flush_duration": "Flush duration after DHW"
+            "flush_duration": "Flush duration after DHW",
+            "dhw_recovery_time": "DHW recovery time"
+          },
+          "data_description": {
+            "dhw_recovery_time": "Under absolute priority, how long circuits stay closed after DHW finishes so the primary flow temperature can fall back to heating levels. Also delays the post-DHW flush window by the same amount."
           }
         }
       },
@@ -272,6 +288,20 @@
       "flush_request": {
         "name": "Flush Request"
       },
+      "dhw_block": {
+        "name": "DHW Block",
+        "state_attributes": {
+          "dhw_priority": {
+            "name": "DHW Priority"
+          },
+          "dhw_active": {
+            "name": "DHW Active"
+          },
+          "dhw_block_until": {
+            "name": "Block Until"
+          }
+        }
+      },
       "status": {
         "name": "Status",
         "state_attributes": {
@@ -309,6 +339,15 @@
     "switch": {
       "flush_enabled": {
         "name": "Flush Enabled"
+      }
+    }
+  },
+  "selector": {
+    "dhw_priority": {
+      "options": {
+        "parallel": "Parallel - heating runs during DHW",
+        "partial": "Partial - open circuits continue, closed ones wait",
+        "absolute": "Absolute - all circuits close during DHW"
       }
     }
   }

--- a/custom_components/ufh_controller/strings.json
+++ b/custom_components/ufh_controller/strings.json
@@ -321,6 +321,13 @@
               "fail_safe": "Fail-Safe"
             }
           },
+          "fail_safe_reason": {
+            "name": "Reason",
+            "state": {
+              "dhw_sensor_unavailable": "DHW sensor unavailable",
+              "zone_failures": "Zone failures"
+            }
+          },
           "consecutive_failures": {
             "name": "Consecutive Failures"
           },

--- a/custom_components/ufh_controller/strings.json
+++ b/custom_components/ufh_controller/strings.json
@@ -18,7 +18,8 @@
       }
     },
     "error": {
-      "already_configured": "This controller is already configured."
+      "already_configured": "This controller is already configured.",
+      "dhw_priority_requires_sensor": "Absolute priority needs a DHW active sensor to detect when charging starts and stops. Without one it would never close any circuit. Configure the sensor, or choose a different priority."
     }
   },
   "options": {
@@ -117,6 +118,9 @@
           "preset_boost": "Boost temperature"
         }
       }
+    },
+    "error": {
+      "dhw_priority_requires_sensor": "Absolute priority needs a DHW active sensor to detect when charging starts and stops. Without one it would never close any circuit. Configure the sensor, or choose a different priority."
     }
   },
   "config_subentries": {

--- a/custom_components/ufh_controller/translations/en.json
+++ b/custom_components/ufh_controller/translations/en.json
@@ -297,6 +297,9 @@
           "dhw_active": {
             "name": "DHW Active"
           },
+          "dhw_sensor_available": {
+            "name": "DHW Sensor Available"
+          },
           "dhw_block_until": {
             "name": "Block Until"
           }

--- a/custom_components/ufh_controller/translations/en.json
+++ b/custom_components/ufh_controller/translations/en.json
@@ -9,7 +9,11 @@
           "pump_request_entity": "Pump request switch",
           "heat_request_entity": "Heat request switch",
           "dhw_active_entity": "DHW active sensor",
+          "dhw_priority": "DHW priority",
           "summer_mode_entity": "Summer mode select"
+        },
+        "data_description": {
+          "dhw_priority": "How heating circuits behave while the heat source is charging domestic hot water. Choose Absolute if DHW charging raises the flow temperature above what your floor construction tolerates and no mixing valve or diverter protects the manifold."
         }
       }
     },
@@ -33,7 +37,11 @@
           "pump_request_entity": "Pump request switch",
           "heat_request_entity": "Heat request switch",
           "dhw_active_entity": "DHW active sensor",
+          "dhw_priority": "DHW priority",
           "summer_mode_entity": "Summer mode select"
+        },
+        "data_description": {
+          "dhw_priority": "How heating circuits behave while the heat source is charging domestic hot water. Choose Absolute if DHW charging raises the flow temperature above what your floor construction tolerates and no mixing valve or diverter protects the manifold."
         }
       },
       "timing": {
@@ -46,7 +54,11 @@
           "closing_warning_duration": "Closing warning duration",
           "window_block_time": "Window block time",
           "controller_loop_interval": "Controller loop interval",
-          "flush_duration": "Flush duration after DHW"
+          "flush_duration": "Flush duration after DHW",
+          "dhw_recovery_time": "DHW recovery time"
+        },
+        "data_description": {
+          "dhw_recovery_time": "Under absolute priority, how long circuits stay closed after DHW finishes so the primary flow temperature can fall back to heating levels. Also delays the post-DHW flush window by the same amount."
         }
       },
       "heat_accounting": {
@@ -126,7 +138,11 @@
             "closing_warning_duration": "Closing warning duration",
             "window_block_time": "Window block time",
             "controller_loop_interval": "Controller loop interval",
-            "flush_duration": "Flush duration after DHW"
+            "flush_duration": "Flush duration after DHW",
+            "dhw_recovery_time": "DHW recovery time"
+          },
+          "data_description": {
+            "dhw_recovery_time": "Under absolute priority, how long circuits stay closed after DHW finishes so the primary flow temperature can fall back to heating levels. Also delays the post-DHW flush window by the same amount."
           }
         }
       },
@@ -272,6 +288,20 @@
       "flush_request": {
         "name": "Flush Request"
       },
+      "dhw_block": {
+        "name": "DHW Block",
+        "state_attributes": {
+          "dhw_priority": {
+            "name": "DHW Priority"
+          },
+          "dhw_active": {
+            "name": "DHW Active"
+          },
+          "dhw_block_until": {
+            "name": "Block Until"
+          }
+        }
+      },
       "status": {
         "name": "Status",
         "state_attributes": {
@@ -309,6 +339,15 @@
     "switch": {
       "flush_enabled": {
         "name": "Flush Enabled"
+      }
+    }
+  },
+  "selector": {
+    "dhw_priority": {
+      "options": {
+        "parallel": "Parallel - heating runs during DHW",
+        "partial": "Partial - open circuits continue, closed ones wait",
+        "absolute": "Absolute - all circuits close during DHW"
       }
     }
   }

--- a/custom_components/ufh_controller/translations/en.json
+++ b/custom_components/ufh_controller/translations/en.json
@@ -321,6 +321,13 @@
               "fail_safe": "Fail-Safe"
             }
           },
+          "fail_safe_reason": {
+            "name": "Reason",
+            "state": {
+              "dhw_sensor_unavailable": "DHW sensor unavailable",
+              "zone_failures": "Zone failures"
+            }
+          },
           "consecutive_failures": {
             "name": "Consecutive Failures"
           },

--- a/custom_components/ufh_controller/translations/en.json
+++ b/custom_components/ufh_controller/translations/en.json
@@ -18,7 +18,8 @@
       }
     },
     "error": {
-      "already_configured": "This controller is already configured."
+      "already_configured": "This controller is already configured.",
+      "dhw_priority_requires_sensor": "Absolute priority needs a DHW active sensor to detect when charging starts and stops. Without one it would never close any circuit. Configure the sensor, or choose a different priority."
     }
   },
   "options": {
@@ -117,6 +118,9 @@
           "preset_boost": "Boost temperature"
         }
       }
+    },
+    "error": {
+      "dhw_priority_requires_sensor": "Absolute priority needs a DHW active sensor to detect when charging starts and stops. Without one it would never close any circuit. Configure the sensor, or choose a different priority."
     }
   },
   "config_subentries": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,4 +81,4 @@ Dependencies flow downward:
 
 ### 4. Fault Isolation
 
-Zones track their own failure state independently. One zone failing doesn't affect other zones. The controller aggregates zone statuses to determine overall health.
+Zones track their own failure state independently. One zone failing doesn't affect other zones. The controller aggregates zone statuses to determine overall health, and a controller-level fault can raise that status further. See [fault_isolation.md](fault_isolation.md#controller-status).

--- a/docs/config_flow.md
+++ b/docs/config_flow.md
@@ -21,6 +21,7 @@ To control the boiler, configure either a Heat Request Switch or Summer Mode Sel
 | pump_request_entity | entity (switch) | No | Switch to control independent circulation pump |
 | heat_request_entity | entity (switch) | No | Switch to signal heat demand to boiler |
 | dhw_active_entity | entity (binary_sensor) | No | Sensor indicating DHW tank is heating |
+| dhw_priority | select | No | How circuits behave during DHW: `parallel`, `partial` (default) or `absolute` |
 | summer_mode_entity | entity (select) | No | Select to enable/disable boiler UFH circuit |
 
 On entry setup, a **controller subentry** is automatically created to:
@@ -75,6 +76,7 @@ The options flow provides access to **timing parameters** that apply to the enti
 | window_block_time | number (s) | Window open time to trigger blocking (default: 600s / 10min) |
 | controller_loop_interval | number (s) | PID update interval (default: 60s / 1min) |
 | flush_duration | number (s) | Flush duration after DHW ends (default: 480s / 8min) |
+| dhw_recovery_time | number (s) | Hold-off after DHW under absolute priority (default: 300s / 5min) |
 
 These settings are stored in the **controller subentry** data.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -450,7 +450,7 @@ A switch entity that signals the boiler to provide heat. When zones request heat
 
 A binary sensor indicating when the boiler is heating domestic hot water (DHW).
 
-**How it works:** When this sensor is "on", DHW priority is activated:
+**How it works:** When this sensor is "on", DHW priority is activated. What that means depends on [dhw_priority](#dhw_priority); the default (`partial`) behaves as follows:
 
 - **Regular circuits already ON**: Continue running (STAY_ON). This allows existing heating to continue circulating water through the floor, maintaining heat distribution even though no new heat is being added.
 - **Regular circuits currently OFF**: Cannot turn ON (STAY_OFF). New heating cycles are blocked until DHW completes.
@@ -459,6 +459,50 @@ A binary sensor indicating when the boiler is heating domestic hot water (DHW).
 **Example:** `binary_sensor.boiler_tapwater_active` → When DHW heating starts, this turns on. Regular zones that were already heating continue to circulate water, but zones that were off wait until DHW finishes.
 
 **Why it matters:** Prevents new heating demands from competing with DHW heating, which typically has priority. Allowing existing valves to stay open enables continued water circulation through the thermal mass of the floor, providing some heat distribution even during DHW priority. Also enables flush circuits to capture waste heat.
+
+#### dhw_priority
+
+**Type:** Select (`parallel` / `partial` / `absolute`)
+**Required:** No
+**Default:** `partial`
+**Config location:** ConfigEntry → `data.dhw_priority`
+
+How the heating circuits behave while the heat source is charging domestic hot water. The naming follows established boiler control terminology (*Vorrangschaltung*), where the same three positions appear on Viessmann, Vaillant, Buderus and Weishaupt controls.
+
+| Value | Behaviour while DHW is active |
+|-------|-------------------------------|
+| `parallel` | No restriction. Zone scheduling ignores DHW entirely. |
+| `partial` | Circuits already open stay open; closed circuits cannot start. This is the historical behaviour and the default. |
+| `absolute` | **All circuits are actively closed** for the duration of DHW plus [dhw_recovery_time](#dhw_recovery_time). |
+
+**How it works:** `parallel` and `partial` never close a running circuit. `absolute` does: it overrides the already-on path, the end-of-period valve freeze, and applies to flush circuits as well as regular ones. It also suppresses the boiler heat request while in force. It applies in `heat`, `flush` and `cycle` modes; the manual overrides `all_on`, `all_off` and `off` state explicit user intent and are left alone.
+
+**Which one do I need?** Look at what your heat source does to the flow temperature when it charges the cylinder:
+
+- If a **3-way diverter valve** hydraulically isolates the heating circuit during DHW, or a **mixing valve** on the manifold limits flow temperature independently, DHW water never reaches your floor. Use `parallel` or `partial`.
+- If the boiler simply raises its flow setpoint for DHW — for example ~45 °C for heating and ~70 °C for the cylinder — and nothing isolates or mixes the manifold, then **any open zone valve puts cylinder-temperature water into your screed**. Use `absolute`.
+
+**Example:** A boiler running 45 °C for underfloor heating and 70 °C for cylinder charging, with the underfloor manifold fed directly from the boiler flow. With `partial`, a zone that happens to be open when DHW starts keeps circulating 70 °C water through the floor. With `absolute`, that zone is commanded closed the moment DHW asserts.
+
+**Why it matters:** Sustained over-temperature flow damages screed and floor coverings — wood and vinyl generally want a surface temperature at or below 27 °C — and thermal shock stresses the pipework. `absolute` is a safety setting, not a comfort preference.
+
+**Limitation to be aware of:** Thermal actuators typically need around 3.5 minutes to close (see [valve_close_time](#valve_close_time)). The controller commands closure the instant DHW asserts, but it cannot make the valve close faster than the hardware allows, so a brief exposure window is unavoidable. Where the boiler offers its own diverter valve or a mixing valve can be fitted, that hardware solution remains preferable to a software one.
+
+#### dhw_recovery_time
+
+**Type:** Integer (seconds)
+**Default:** 300 (5 minutes)
+**Config location:** Controller subentry → `data.timing.dhw_recovery_time`
+
+How long circuits stay closed after DHW charging ends, under `absolute` priority only.
+
+**How it works:** When the DHW sensor transitions from ON to OFF, the block is held for a further `dhw_recovery_time` seconds. The primary circuit still holds cylinder-temperature water at that moment, so reopening immediately would be nearly as damaging as opening during the charge itself. Set to 0 to release circuits as soon as DHW ends.
+
+**Interaction with the flush feature:** The post-DHW [flush window](#flush_duration) is deferred by the same amount rather than shortened. With `dhw_recovery_time=300` and `flush_duration=480`, flush circuits are eligible from 5 minutes after DHW ends until 13 minutes after. The configured flush duration is fully preserved.
+
+**A caution on latent heat capture under `absolute`:** the recovery hold-off makes deferred harvesting *safer*, not provably *safe*. On a system with no mixing valve there is no guarantee the primary has actually cooled by the time the window opens — the timer is an estimate, not a measurement. Unless you have a supply temperature sensor confirming the primary has come down, consider leaving `flush_enabled` off on these systems. It defaults to off.
+
+**Why it matters:** Without a hold-off, the controller would reopen circuits into a primary that is still at cylinder temperature, defeating the point of `absolute` priority.
 
 #### summer_mode_entity
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -494,10 +494,14 @@ The fault escalates in two stages, matching how zone failures already escalate:
 
 | Stage | When | Effect |
 |-------|------|--------|
-| Block | First cycle that cannot read the sensor | All circuits closed, both timers frozen, controller status `degraded` |
+| Block | First control cycle that cannot read the sensor | All circuits closed, both deadlines held, controller status `degraded` |
 | Escalation | Fault sustained for 1 hour | Controller status `fail_safe`; valves closed in every mode except `off`, and boiler summer mode set to `auto` |
 
-The timers freeze rather than run, because an unreadable sensor gives nothing to detect a DHW end from. When the sensor returns, the recovery hold-off is timed from the moment visibility was regained.
+The deadlines are held rather than advanced, because an unreadable sensor gives nothing to detect a DHW end from. When the sensor returns, the recovery hold-off is timed from the moment visibility was regained.
+
+**Detection is on the control cycle, not instantaneous.** A sensor going unavailable does not trigger an immediate re-evaluation, so the block engages on the next cycle — within `controller_loop_interval` (default 60 s). This is deliberate: it debounces brief dropouts, which would otherwise close and reopen every valve for a momentary reconnect.
+
+**Nothing is commanded during startup.** While the controller is `initializing` — up to two minutes, until every configured entity has reported — no valve command is issued at all, including this block. The controller does not act on state it cannot yet track. A valve left open across a restart therefore stays as it is until initialization completes.
 
 The `dhw_block` sensor's `dhw_sensor_available` attribute and the `status` sensor's `fail_safe_reason` attribute both show when this is happening.
 
@@ -519,7 +523,9 @@ How long circuits stay closed after DHW charging ends, under `absolute` priority
 
 **How it works:** When the DHW sensor transitions from ON to OFF, the block is held for a further `dhw_recovery_time` seconds. The primary circuit still holds cylinder-temperature water at that moment, so reopening immediately would be nearly as damaging as opening during the charge itself. Set to 0 to release circuits as soon as DHW ends.
 
-**Interaction with the flush feature:** The post-DHW [flush window](#flush_duration) is deferred by the same amount rather than shortened. With `dhw_recovery_time=300` and `flush_duration=480`, flush circuits are eligible from 5 minutes after DHW ends until 13 minutes after. The configured flush duration is fully preserved.
+**Interaction with the flush feature:** The post-DHW [flush window](#flush_duration) is deferred rather than cancelled. With `dhw_recovery_time=300` and `flush_duration=480`, flush circuits are eligible from 5 minutes after DHW ends until 13 minutes after.
+
+The window closes at a fixed time, so anything that delays its start eats into it rather than shifting it. If the DHW sensor drops out during the hold-off, the block persists until the sensor returns and only the remainder of the window is used — a 90-second dropout leaves 390 seconds of a configured 480. That is the safe direction, since the delay implies the primary was hotter for longer than expected.
 
 **A caution on latent heat capture under `absolute`:** the recovery hold-off makes deferred harvesting *safer*, not provably *safe*. On a system with no mixing valve there is no guarantee the primary has actually cooled by the time the window opens — the timer is an estimate, not a measurement. Unless you have a supply temperature sensor confirming the primary has come down, consider leaving `flush_enabled` off on these systems. It defaults to off.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -488,7 +488,24 @@ How the heating circuits behave while the heat source is charging domestic hot w
 
 **Requires a DHW sensor.** `absolute` cannot function without [dhw_active_entity](#dhw_active_entity) — the controller would never learn that a charge had started. The config flow rejects the combination rather than accepting a setting that silently does nothing.
 
-**Behaviour when the DHW sensor drops out:** under `absolute`, an `unavailable` or `unknown` reading holds the last known DHW state instead of being treated as "off". Treating it as off would synthesise a false end-of-charge, start the recovery countdown, and reopen every circuit mid-charge. The `dhw_block` sensor's `dhw_sensor_available` attribute shows when this is happening. `parallel` and `partial` keep the historical behaviour of treating an unusable reading as off, where the cost is comfort rather than damage.
+**Behaviour when the DHW sensor drops out:** under `absolute`, a sensor that is missing, `unavailable` or `unknown` is treated as a **fault**, not as a state to be guessed. Absolute priority exists because you must be certain DHW is not charging before opening a circuit, and neither "assume off" nor "assume the last known value" provides that certainty.
+
+The fault escalates in two stages, matching how zone failures already escalate:
+
+| Stage | When | Effect |
+|-------|------|--------|
+| Block | First cycle that cannot read the sensor | All circuits closed, both timers frozen, controller status `degraded` |
+| Escalation | Fault sustained for 1 hour | Controller status `fail_safe`; valves closed in every mode except `off`, and boiler summer mode set to `auto` |
+
+The timers freeze rather than run, because an unreadable sensor gives nothing to detect a DHW end from. When the sensor returns, the recovery hold-off is timed from the moment visibility was regained.
+
+The `dhw_block` sensor's `dhw_sensor_available` attribute and the `status` sensor's `fail_safe_reason` attribute both show when this is happening.
+
+**Residual risk:** while the sensor is unreadable, you have **no heating at all**. This is deliberate — the DHW hazard is chosen over the freeze hazard — but be aware that the `auto` summer mode at escalation does *not* soften it: the controller keeps every valve shut, so the boiler's own thermostats cannot deliver floor heat either. Watch `binary_sensor.{controller_id}_status`, which reports a problem from the first blocked cycle.
+
+**A note on flapping sensors:** because the block latches immediately, a brief dropout (an MQTT reconnect, a gateway reboot) closes every valve and reopens them, bypassing `min_run_time`. This is partly self-limiting, since actuators need around `valve_close_time` to travel, so a short flap may not move the valve far.
+
+`parallel` and `partial` keep the historical behaviour of treating an unreadable reading as off, where the cost is comfort rather than damage, and never raise this fault.
 
 **Limitation to be aware of:** Thermal actuators typically need around 3.5 minutes to close (see [valve_close_time](#valve_close_time)). The controller commands closure the instant DHW asserts, but it cannot make the valve close faster than the hardware allows, so a brief exposure window is unavoidable. Where the boiler offers its own diverter valve or a mixing valve can be fitted, that hardware solution remains preferable to a software one.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -475,7 +475,7 @@ How the heating circuits behave while the heat source is charging domestic hot w
 | `partial` | Circuits already open stay open; closed circuits cannot start. This is the historical behaviour and the default. |
 | `absolute` | **All circuits are actively closed** for the duration of DHW plus [dhw_recovery_time](#dhw_recovery_time). |
 
-**How it works:** `parallel` and `partial` never close a running circuit. `absolute` does: it overrides the already-on path, the end-of-period valve freeze, and applies to flush circuits as well as regular ones. It also suppresses the boiler heat request while in force. It applies in `heat`, `flush` and `cycle` modes; the manual overrides `all_on`, `all_off` and `off` state explicit user intent and are left alone.
+**How it works:** `parallel` and `partial` never close a running circuit. `absolute` does: it overrides the already-on path, the end-of-period valve freeze, and applies to flush circuits as well as regular ones. It also suppresses both the boiler heat request and the pump request while in force, so an independent circulation pump stops immediately rather than pushing cylinder-temperature water through circuits that are still closing. It applies in `heat`, `flush` and `cycle` modes; the manual overrides `all_on`, `all_off` and `off` state explicit user intent and are left alone.
 
 **Which one do I need?** Look at what your heat source does to the flow temperature when it charges the cylinder:
 
@@ -485,6 +485,10 @@ How the heating circuits behave while the heat source is charging domestic hot w
 **Example:** A boiler running 45 °C for underfloor heating and 70 °C for cylinder charging, with the underfloor manifold fed directly from the boiler flow. With `partial`, a zone that happens to be open when DHW starts keeps circulating 70 °C water through the floor. With `absolute`, that zone is commanded closed the moment DHW asserts.
 
 **Why it matters:** Sustained over-temperature flow damages screed and floor coverings — wood and vinyl generally want a surface temperature at or below 27 °C — and thermal shock stresses the pipework. `absolute` is a safety setting, not a comfort preference.
+
+**Requires a DHW sensor.** `absolute` cannot function without [dhw_active_entity](#dhw_active_entity) — the controller would never learn that a charge had started. The config flow rejects the combination rather than accepting a setting that silently does nothing.
+
+**Behaviour when the DHW sensor drops out:** under `absolute`, an `unavailable` or `unknown` reading holds the last known DHW state instead of being treated as "off". Treating it as off would synthesise a false end-of-charge, start the recovery countdown, and reopen every circuit mid-charge. The `dhw_block` sensor's `dhw_sensor_available` attribute shows when this is happening. `parallel` and `partial` keep the historical behaviour of treating an unusable reading as off, where the cost is comfort rather than damage.
 
 **Limitation to be aware of:** Thermal actuators typically need around 3.5 minutes to close (see [valve_close_time](#valve_close_time)). The controller commands closure the instant DHW asserts, but it cannot make the valve close faster than the hardware allows, so a brief exposure window is unavoidable. Where the boiler offers its own diverter valve or a mixing valve can be fitted, that hardware solution remains preferable to a software one.
 

--- a/docs/control_algorithm.md
+++ b/docs/control_algorithm.md
@@ -97,7 +97,7 @@ The controller computes a single heat request signal from all zones with active 
 - Only zones with `flow=True` (valve confirmed fully open) are considered
 - A zone contributes to the heat request when its `remaining_duration` exceeds the `closing_warning_duration` (zone won't close imminently)
 - If any qualifying zone needs heat, the boiler heat request is enabled
-- While a DHW block is in force the heat request is suppressed outright. Thermal actuators take minutes to close, so a circuit still reports flow immediately after DHW asserts; without this the controller would ask the boiler to fire for space heating mid-charge. Pump request stays flow-driven and decays naturally as the valves close.
+- While a DHW block is in force both the heat request and the pump request are suppressed outright. Thermal actuators take minutes to close, so a circuit still reports flow immediately after DHW asserts; without this the controller would ask the boiler to fire mid-charge and keep an independent circulation pump pushing cylinder-temperature water through the closing circuit.
 
 ### Boiler Summer Mode Management
 

--- a/docs/control_algorithm.md
+++ b/docs/control_algorithm.md
@@ -65,25 +65,29 @@ See [Heat Accounting](heat_accounting.md) for detailed documentation.
 
 The zone evaluation follows a priority-based decision tree:
 
-1. **Flush circuit priority:** If flush is enabled and DHW has recently ended with no regular circuits currently running, flush circuits turn on to capture latent heat from the boiler.
+1. **Absolute DHW priority:** If `dhw_priority` is `absolute` and DHW is charging (or the `dhw_recovery_time` hold-off has not expired), every circuit is driven closed. This overrides all the steps below, including the already-on and end-of-period-freeze paths, because the hazard it guards against is hydraulic rather than thermal — see [dhw_priority](configuration.md#dhw_priority).
 
-2. **End-of-period freeze:** When less than `min_run_time` remains in the observation period, valve positions are frozen to prevent unnecessary cycling at period boundaries.
+2. **Flush circuit priority:** If flush is enabled and DHW has recently ended with no regular circuits currently running, flush circuits turn on to capture latent heat from the boiler.
 
-3. **Quota-based scheduling:** For zones that haven't met their quota:
+3. **End-of-period freeze:** When less than `min_run_time` remains in the observation period, valve positions are frozen to prevent unnecessary cycling at period boundaries.
+
+4. **Quota-based scheduling:** For zones that haven't met their quota:
    - If valve is already on: stay on (commands are re-sent to prevent relay timeout)
    - If estimated wall clock runtime is less than `min_run_time`: stay off (not worth a short run).
      When a supply coefficient is available, remaining quota is converted to estimated wall clock time
      (capped at remaining quota so coefficients above 100% never shorten the estimate):
      `estimated_runtime = max(remaining_quota, remaining_quota / (supply_coefficient / 100))`.
      Without a supply sensor, remaining quota is compared directly.
-   - If DHW is active and this is a regular circuit currently off: stay off (DHW priority)
+   - If `dhw_priority` is `partial` (the default), DHW is active and this is a regular circuit currently off: stay off. Circuits already running are left alone; `parallel` skips this check entirely.
    - Otherwise: turn on
 
-4. **Quota met:** For zones that have met their quota:
+5. **Quota met:** For zones that have met their quota:
    - If valve is on: turn off
    - If valve is off: stay off
 
-**Note:** Window blocking affects PID integration (pausing accumulation), not valve control directly. Valves follow quota-based scheduling regardless of window state.
+**Note:** Window blocking affects PID integration (pausing accumulation), not valve control directly. Valves follow quota-based scheduling regardless of window state. Absolute DHW priority is the one exception that does close valves, since no amount of PID pausing keeps DHW-temperature water out of the floor.
+
+**Note:** PID integration continues normally during a DHW block. The room temperature reading stays valid and the room really is losing heat, so the integral builds and the zone catches up once the block clears. Quota is preserved rather than compensated: `used_duration` does not advance while a circuit is closed.
 
 ### Heat Request Logic
 
@@ -91,6 +95,7 @@ The controller computes a single heat request signal from all zones with active 
 - Only zones with `flow=True` (valve confirmed fully open) are considered
 - A zone contributes to the heat request when its `remaining_duration` exceeds the `closing_warning_duration` (zone won't close imminently)
 - If any qualifying zone needs heat, the boiler heat request is enabled
+- While a DHW block is in force the heat request is suppressed outright. Thermal actuators take minutes to close, so a circuit still reports flow immediately after DHW asserts; without this the controller would ask the boiler to fire for space heating mid-charge. Pump request stays flow-driven and decays naturally as the valves close.
 
 ### Boiler Summer Mode Management
 

--- a/docs/control_algorithm.md
+++ b/docs/control_algorithm.md
@@ -87,7 +87,9 @@ The zone evaluation follows a priority-based decision tree:
 
 **Note:** Window blocking affects PID integration (pausing accumulation), not valve control directly. Valves follow quota-based scheduling regardless of window state. Absolute DHW priority is the one exception that does close valves, since no amount of PID pausing keeps DHW-temperature water out of the floor.
 
-**Note:** PID integration continues normally during a DHW block. The room temperature reading stays valid and the room really is losing heat, so the integral builds and the zone catches up once the block clears. Quota is preserved rather than compensated: `used_duration` does not advance while a circuit is closed.
+**Note:** PID integration continues normally during a DHW block. The room temperature reading stays valid and the room really is losing heat, so the integral builds and the zone catches up once the block clears.
+
+**Note:** Quota is preserved rather than compensated, but not instantly. `used_duration` accrues while `flow` is true, and `flow` is derived from the estimated valve position, which ramps down over `valve_close_time` after the block commands the valve shut. A zone therefore keeps consuming quota for roughly the first 15% of `valve_close_time` (about 30 s at the default 210 s) before flow drops below the 0.85 threshold. That is deliberate: during that window the circuit is receiving cylinder-temperature water, so it is being charged for heat it genuinely got. If DHW spans an observation-period boundary the unused remainder is dropped, which the PID integral self-corrects over the next period.
 
 ### Heat Request Logic
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -28,7 +28,8 @@ The DHW block sensor reports whether the [absolute DHW priority](configuration.m
 - **Manual override modes ignore it:** `heat`, `flush` and `cycle` act on the block; `all_on` and `off` do not, so the sensor can read ON while those modes hold valves open. Read it alongside the mode select rather than as a guarantee about valve positions
 - **Attributes:** `dhw_priority` (the configured level), `dhw_active` (resolved DHW state), `dhw_sensor_available` (false while the DHW sensor is unavailable and the block is being held) and `dhw_block_until` (when the hold-off expires)
 - **Survives restarts:** the recovery deadline is persisted, so a restart or an options change mid-recovery does not release circuits early. Only deadlines are restored; everything else is recomputed from live inputs
-- **DHW sensor unreadable:** under `absolute` this is a fault — circuits are blocked and the controller goes `degraded`, escalating to `fail_safe` after an hour. See [dhw_priority](configuration.md#dhw_priority)
+- **DHW sensor unreadable:** under `absolute` this is a fault — circuits are blocked and the controller goes `degraded`, escalating to `fail_safe` after an hour. Detected on the next control cycle rather than instantly, which debounces brief dropouts. See [dhw_priority](configuration.md#dhw_priority)
+- **Only armed under `absolute`:** `dhw_block_until` stays empty for `parallel` and `partial`, since no block can engage there
 
 **Flush Enabled Behavior:**
 - **Enabled:** Flush-type circuits can turn on for a configurable period after DHW ends (`flush_duration`) to capture latent heat (only when no regular circuits are currently running with valve ON).

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -25,7 +25,8 @@ All controller entities belong to a device named after the controller (user-defi
 The DHW block sensor reports whether [absolute DHW priority](configuration.md#dhw_priority) is currently forcing every circuit closed:
 - **ON:** While DHW is charging, and throughout the `dhw_recovery_time` hold-off after it ends
 - **OFF:** Whenever `dhw_priority` is `parallel` or `partial`, since neither closes running circuits
-- **Attributes:** `dhw_priority` (the configured level), `dhw_active` (the raw sensor state) and `dhw_block_until` (when the hold-off expires)
+- **Attributes:** `dhw_priority` (the configured level), `dhw_active` (resolved DHW state), `dhw_sensor_available` (false while the DHW sensor is unavailable and the block is being held) and `dhw_block_until` (when the hold-off expires)
+- **Survives restarts:** the block and its deadline are persisted, so a restart or an options change mid-recovery does not release circuits early
 
 **Flush Enabled Behavior:**
 - **Enabled:** Flush-type circuits can turn on for a configurable period after DHW ends (`flush_duration`) to capture latent heat (only when no regular circuits are currently running with valve ON).

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -13,7 +13,7 @@ All controller entities belong to a device named after the controller (user-defi
 | sensor | `sensor.{controller_id}_zones_heating`  | "{name} Zones Heating"  | Count of zones currently receiving heat |
 | sensor | `sensor.{controller_id}_zones_window`  | "{name} Zones Window"  | Count of zones with recent window activity |
 | sensor | `sensor.{controller_id}_supply_target_temp`     | "{name} Supply Target Temperature"     | Calculated supply target from heating curve (only when `outdoor_temp_entity` configured) |
-| binary_sensor | `binary_sensor.{controller_id}_status` | "{name} Status" | Controller operational status (problem when degraded/fail-safe) |
+| binary_sensor | `binary_sensor.{controller_id}_status` | "{name} Status" | Controller operational status (problem when degraded/fail-safe); `fail_safe_reason` attribute names the cause |
 | binary_sensor | `binary_sensor.{controller_id}_pump_request` | "{name} Pump Request" | Pump is requested for water circulation through zones |
 | binary_sensor | `binary_sensor.{controller_id}_heat_request` | "{name} Heat Request" | Controller is requesting heat from the boiler |
 | binary_sensor | `binary_sensor.{controller_id}_flush_request` | "{name} Flush Request" | Flush is actively running (only when `dhw_active_entity` configured) |
@@ -27,7 +27,8 @@ The DHW block sensor reports whether the [absolute DHW priority](configuration.m
 - **OFF:** Whenever `dhw_priority` is `parallel` or `partial`, since neither closes running circuits
 - **Manual override modes ignore it:** `heat`, `flush` and `cycle` act on the block; `all_on` and `off` do not, so the sensor can read ON while those modes hold valves open. Read it alongside the mode select rather than as a guarantee about valve positions
 - **Attributes:** `dhw_priority` (the configured level), `dhw_active` (resolved DHW state), `dhw_sensor_available` (false while the DHW sensor is unavailable and the block is being held) and `dhw_block_until` (when the hold-off expires)
-- **Survives restarts:** the block and its deadline are persisted, so a restart or an options change mid-recovery does not release circuits early
+- **Survives restarts:** the recovery deadline is persisted, so a restart or an options change mid-recovery does not release circuits early. Only deadlines are restored; everything else is recomputed from live inputs
+- **DHW sensor unreadable:** under `absolute` this is a fault — circuits are blocked and the controller goes `degraded`, escalating to `fail_safe` after an hour. See [dhw_priority](configuration.md#dhw_priority)
 
 **Flush Enabled Behavior:**
 - **Enabled:** Flush-type circuits can turn on for a configurable period after DHW ends (`flush_duration`) to capture latent heat (only when no regular circuits are currently running with valve ON).

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -22,9 +22,10 @@ All controller entities belong to a device named after the controller (user-defi
 **Note:** The flush enabled switch, flush request sensor and DHW block sensor are only created when `dhw_active_entity` is configured, as all three require DHW state input to function.
 
 **DHW Block Behavior:**
-The DHW block sensor reports whether [absolute DHW priority](configuration.md#dhw_priority) is currently forcing every circuit closed:
+The DHW block sensor reports whether the [absolute DHW priority](configuration.md#dhw_priority) block *condition* is in force — not whether valves are currently closed:
 - **ON:** While DHW is charging, and throughout the `dhw_recovery_time` hold-off after it ends
 - **OFF:** Whenever `dhw_priority` is `parallel` or `partial`, since neither closes running circuits
+- **Manual override modes ignore it:** `heat`, `flush` and `cycle` act on the block; `all_on` and `off` do not, so the sensor can read ON while those modes hold valves open. Read it alongside the mode select rather than as a guarantee about valve positions
 - **Attributes:** `dhw_priority` (the configured level), `dhw_active` (resolved DHW state), `dhw_sensor_available` (false while the DHW sensor is unavailable and the block is being held) and `dhw_block_until` (when the hold-off expires)
 - **Survives restarts:** the block and its deadline are persisted, so a restart or an options change mid-recovery does not release circuits early
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -17,18 +17,26 @@ All controller entities belong to a device named after the controller (user-defi
 | binary_sensor | `binary_sensor.{controller_id}_pump_request` | "{name} Pump Request" | Pump is requested for water circulation through zones |
 | binary_sensor | `binary_sensor.{controller_id}_heat_request` | "{name} Heat Request" | Controller is requesting heat from the boiler |
 | binary_sensor | `binary_sensor.{controller_id}_flush_request` | "{name} Flush Request" | Flush is actively running (only when `dhw_active_entity` configured) |
+| binary_sensor | `binary_sensor.{controller_id}_dhw_block` | "{name} DHW Block" | Absolute DHW priority is holding circuits closed (only when `dhw_active_entity` configured) |
 
-**Note:** The flush enabled switch and flush request sensor are only created when `dhw_active_entity` is configured, as the DHW latent heat capture feature requires DHW state input to function.
+**Note:** The flush enabled switch, flush request sensor and DHW block sensor are only created when `dhw_active_entity` is configured, as all three require DHW state input to function.
+
+**DHW Block Behavior:**
+The DHW block sensor reports whether [absolute DHW priority](configuration.md#dhw_priority) is currently forcing every circuit closed:
+- **ON:** While DHW is charging, and throughout the `dhw_recovery_time` hold-off after it ends
+- **OFF:** Whenever `dhw_priority` is `parallel` or `partial`, since neither closes running circuits
+- **Attributes:** `dhw_priority` (the configured level), `dhw_active` (the raw sensor state) and `dhw_block_until` (when the hold-off expires)
 
 **Flush Enabled Behavior:**
 - **Enabled:** Flush-type circuits can turn on for a configurable period after DHW ends (`flush_duration`) to capture latent heat (only when no regular circuits are currently running with valve ON).
 - **Disabled:** Flush-type circuits behave like regular circuits — no special DHW priority.
-- **DHW priority for regular zones is independent of this setting.** Regular zones that are OFF cannot turn ON during DHW heating regardless of the flush enabled state. This switch only controls whether flush circuits get special treatment.
+- **DHW priority for regular zones is independent of this setting.** Under the default `partial` priority, regular zones that are OFF cannot turn ON during DHW heating regardless of the flush enabled state. This switch only controls whether flush circuits get special treatment.
+- **Under `absolute` priority, latent heat capture is deferred, not cancelled.** The flush window opens only after `dhw_recovery_time` has elapsed, at its full `flush_duration`. Consider leaving this switch off on unmixed systems — see [dhw_priority](configuration.md#dhw_priority).
 
 **Flush Request Behavior:**
 The flush request sensor indicates when flush circuits are actively capturing heat:
 - **ON:** During the post-DHW flush period
-- **OFF:** When DHW is active or not within the post-DHW flush period
+- **OFF:** When DHW is active, when a DHW block is in force, or when not within the post-DHW flush period
 - **Requires flush_enabled:** The sensor only reports ON if `flush_enabled` switch is also on
 
 **Select Options for Mode:**

--- a/docs/fault_isolation.md
+++ b/docs/fault_isolation.md
@@ -39,6 +39,8 @@ Derived from zone statuses:
 | Some zones failing, at least one normal | `degraded` |
 | All zones in fail-safe | `fail_safe` |
 
+A controller-level fault can then raise this status, but never lower it, so the controller can report `fail_safe` with every zone healthy. The only one today is an unreadable DHW sensor under [`absolute` priority](configuration.md#dhw_priority).
+
 The `binary_sensor.{controller_id}_status` entity shows `on` (problem) when degraded or fail-safe.
 
 When the controller status is `fail_safe`, all valves are closed and pump and heat
@@ -57,10 +59,10 @@ mode to "auto", handing the heating circuit back to the boiler so valve
 controllers acting as offline thermostats can still receive heated water.
 
 This applies in `heat` mode only, whether one zone or all zones have failed. Every
-other mode is an explicit instruction that a zone failure must not override:
+other mode is an explicit instruction that a failure must not override:
 
-| Mode | Summer mode while any zone is in fail-safe |
-|------|--------------------------------------------|
+| Mode | Summer mode while the controller or any zone is in fail-safe |
+|------|--------------------------------------------------------------|
 | `heat` | `auto` — delegated to the boiler |
 | `flush` | `summer` — circulation only, no firing |
 | `cycle` | `summer` — maintenance rotation, no firing |

--- a/docs/operation_modes.md
+++ b/docs/operation_modes.md
@@ -43,7 +43,8 @@ Diagnostic mode that rotates through zones.
 Manual override - maximum heating.
 
 - All valves forced OPEN
-- **Not** overridden by absolute DHW priority: an explicit manual override states user intent
+- **Not** overridden by a normal absolute DHW priority block: an explicit manual override states user intent
+- **Is** overridden by a sustained DHW sensor fault, which reaches controller fail-safe and closes valves in every mode except `off`
 - Pump request ON
 - Heat request ON
 - Boiler summer_mode set to "winter"

--- a/docs/operation_modes.md
+++ b/docs/operation_modes.md
@@ -10,7 +10,7 @@ Default mode. Full PID control with quota-based scheduling.
 - Pump request: flow-gated (on when any zone has confirmed flow)
 - Heat request: flow-gated and gated on pump request
 - Window blocking active
-- DHW priority active (if configured)
+- DHW priority active (if configured), at the configured `dhw_priority` level
 - Post-DHW residual heat capture active (if configured)
 - Boiler summer_mode follows heat request, or "auto" when any zone is in fail-safe
   (see [Fault Isolation](fault_isolation.md#summer-mode-safety))
@@ -20,6 +20,7 @@ Default mode. Full PID control with quota-based scheduling.
 System maintenance mode for pipe flushing.
 
 - All valves forced OPEN
+- Suspended while absolute DHW priority holds circuits closed (all valves CLOSED, pump and heat request OFF); the mode is retained and resumes when the block clears
 - Pump request ON (circulation is the mode's purpose)
 - Heat request OFF
 - Boiler summer_mode set to "summer" (circulation only, no firing)
@@ -30,6 +31,7 @@ System maintenance mode for pipe flushing.
 Diagnostic mode that rotates through zones.
 
 - One zone open at a time on 8-hour rotation
+- Suspended while absolute DHW priority holds circuits closed; the rotation is retained and resumes when the block clears
 - Hour 0: all closed (rest)
 - Hours 1-7: zones open sequentially
 - Pump request: flow-gated (on when the active zone has confirmed flow)
@@ -41,6 +43,7 @@ Diagnostic mode that rotates through zones.
 Manual override - maximum heating.
 
 - All valves forced OPEN
+- **Not** overridden by absolute DHW priority: an explicit manual override states user intent
 - Pump request ON
 - Heat request ON
 - Boiler summer_mode set to "winter"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,6 +33,7 @@ Verify your entities are working before setup:
 | Heat request switch | `switch.boiler_heat_request` | Optional: signals boiler to fire |
 | Summer mode select | `select.boiler_summer_mode` | Optional: EMS-ESP boiler control |
 | DHW active sensor | `binary_sensor.boiler_dhw_active` | Optional: hot water priority |
+| DHW priority | `partial` | How circuits behave during DHW (see below) |
 | Supply temp sensor | `sensor.manifold_supply_temp` | Optional: heat accounting |
 
 ## Step 1: Install the Integration
@@ -78,7 +79,10 @@ Navigate to **Settings → Devices & Services → Add Integration** and search f
 → Leave both blank. The controller will manage valves only.
 
 **Do you want DHW (hot water) priority?**
-→ Configure `dhw_active_entity` to point to a sensor that indicates when your boiler is heating hot water. This prevents new heating cycles during DHW and enables flush circuit heat capture.
+→ Configure `dhw_active_entity` to point to a sensor that indicates when your boiler is heating hot water. On the default `partial` priority this prevents new heating cycles during DHW and enables flush circuit heat capture.
+
+**Does your boiler raise its flow temperature for hot water?**
+→ If it runs, say, 45 °C for heating and 70 °C for the cylinder, and no 3-way diverter or mixing valve protects your manifold, set `dhw_priority` to `absolute`. Otherwise a zone that happens to be open when hot water starts will circulate cylinder-temperature water through your floor. See [dhw_priority](configuration.md#dhw_priority).
 
 **Do you want fair heat accounting?**
 → Configure `supply_temp_entity` to point to your manifold supply temperature sensor, and set `supply_target_temp` to your expected supply temperature (typically 35-45°C for UFH).

--- a/tests/config/test_config_flow_options.py
+++ b/tests/config/test_config_flow_options.py
@@ -13,6 +13,7 @@ from custom_components.ufh_controller.const import (
     DEFAULT_SUPPLY_TEMP_WARM,
     DOMAIN,
     SUBENTRY_TYPE_CONTROLLER,
+    DHWPriority,
 )
 
 
@@ -421,3 +422,54 @@ async def test_options_flow_backwards_compatible(
     assert entry.data["supply_target_temp"] == 42.0
     assert entry.data["outdoor_temp_warm"] == DEFAULT_OUTDOOR_TEMP_WARM
     assert entry.data["outdoor_temp_cold"] == DEFAULT_OUTDOOR_TEMP_COLD
+
+
+async def test_options_flow_update_dhw_priority(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test changing DHW priority via the control entities step."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "control_entities"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "dhw_active_entity": "binary_sensor.dhw_active",
+            "dhw_priority": DHWPriority.ABSOLUTE.value,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_config_entry.data["dhw_priority"] == DHWPriority.ABSOLUTE.value
+
+
+async def test_options_flow_control_entities_defaults_priority(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test an entry predating the option falls back to partial priority."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert "dhw_priority" not in mock_config_entry.data
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "control_entities"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"dhw_active_entity": "binary_sensor.dhw_active"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_config_entry.data["dhw_priority"] == DHWPriority.PARTIAL.value

--- a/tests/config/test_config_flow_options.py
+++ b/tests/config/test_config_flow_options.py
@@ -473,3 +473,27 @@ async def test_options_flow_control_entities_defaults_priority(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_config_entry.data["dhw_priority"] == DHWPriority.PARTIAL.value
+
+
+async def test_options_flow_rejects_absolute_without_dhw_sensor(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the options flow rejects absolute priority with no DHW sensor."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "control_entities"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"dhw_priority": DHWPriority.ABSOLUTE.value},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"dhw_priority": "dhw_priority_requires_sensor"}
+    assert mock_config_entry.data.get("dhw_priority") is None

--- a/tests/config/test_config_flow_options.py
+++ b/tests/config/test_config_flow_options.py
@@ -497,3 +497,38 @@ async def test_options_flow_rejects_absolute_without_dhw_sensor(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"dhw_priority": "dhw_priority_requires_sensor"}
     assert mock_config_entry.data.get("dhw_priority") is None
+
+
+async def test_options_flow_error_keeps_cleared_entity_cleared(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a cleared DHW sensor is not reinstated when validation fails."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.data["dhw_active_entity"] == "binary_sensor.dhw_active"
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "control_entities"},
+    )
+    # Clear the sensor and pick absolute, which is rejected
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"dhw_priority": DHWPriority.ABSOLUTE.value},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"dhw_priority": "dhw_priority_requires_sensor"}
+
+    schema = result["data_schema"]
+    assert schema is not None
+    suggested = {
+        key.schema: key.description.get("suggested_value")
+        for key in schema.schema
+        if getattr(key, "description", None)
+    }
+    assert suggested.get("dhw_active_entity") is None

--- a/tests/config/test_config_flow_user.py
+++ b/tests/config/test_config_flow_user.py
@@ -205,3 +205,46 @@ async def test_user_flow_allows_non_absolute_without_dhw_sensor(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"]["dhw_priority"] == DHWPriority.PARALLEL.value
+
+
+async def test_user_flow_error_preserves_entered_values(
+    hass: HomeAssistant,
+    mock_setup_entry: None,
+) -> None:
+    """
+    Test a validation error costs no typing and keeps the chosen priority.
+
+    Previously every field came back blank and dhw_priority silently reverted
+    to partial, so adding the sensor and resubmitting would quietly configure
+    a weaker setting than the user asked for.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    submitted = {
+        "name": "My Heating",
+        "pump_request_entity": "switch.pump",
+        "heat_request_entity": "switch.boiler",
+        "summer_mode_entity": "select.summer",
+        "dhw_priority": DHWPriority.ABSOLUTE.value,
+    }
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=submitted
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"dhw_priority": "dhw_priority_requires_sensor"}
+
+    schema = result["data_schema"]
+    assert schema is not None
+    redisplayed: dict[str, object] = {}
+    for key in schema.schema:
+        description = getattr(key, "description", None) or {}
+        if "suggested_value" in description:
+            redisplayed[key.schema] = description["suggested_value"]
+        else:
+            redisplayed[key.schema] = key.default()
+
+    for field, value in submitted.items():
+        assert redisplayed[field] == value, f"{field} was not redisplayed"

--- a/tests/config/test_config_flow_user.py
+++ b/tests/config/test_config_flow_user.py
@@ -163,3 +163,45 @@ async def test_user_flow_with_absolute_dhw_priority(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"]["dhw_priority"] == DHWPriority.ABSOLUTE.value
+
+
+async def test_user_flow_rejects_absolute_without_dhw_sensor(
+    hass: HomeAssistant,
+    mock_setup_entry: None,
+) -> None:
+    """Test absolute priority without a DHW sensor is rejected, not silently inert."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            "name": "No Sensor",
+            "dhw_priority": DHWPriority.ABSOLUTE.value,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"dhw_priority": "dhw_priority_requires_sensor"}
+
+
+async def test_user_flow_allows_non_absolute_without_dhw_sensor(
+    hass: HomeAssistant,
+    mock_setup_entry: None,
+) -> None:
+    """Test parallel and partial remain valid with no DHW sensor configured."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            "name": "No Sensor Parallel",
+            "dhw_priority": DHWPriority.PARALLEL.value,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"]["dhw_priority"] == DHWPriority.PARALLEL.value

--- a/tests/config/test_config_flow_user.py
+++ b/tests/config/test_config_flow_user.py
@@ -7,6 +7,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from custom_components.ufh_controller.const import (
     DEFAULT_TIMING,
     DOMAIN,
+    DHWPriority,
 )
 
 
@@ -118,3 +119,47 @@ async def test_user_flow_generates_controller_id(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"]["controller_id"] == "living-room-heating-system"
+
+
+async def test_user_flow_defaults_to_partial_dhw_priority(
+    hass: HomeAssistant,
+    mock_setup_entry: None,
+) -> None:
+    """Test a new entry keeps the historical soft-gate behaviour by default."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"name": "Default Priority"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"]["dhw_priority"] == DHWPriority.PARTIAL.value
+    assert (
+        result["options"]["timing"]["dhw_recovery_time"]
+        == (DEFAULT_TIMING["dhw_recovery_time"])
+    )
+
+
+async def test_user_flow_with_absolute_dhw_priority(
+    hass: HomeAssistant,
+    mock_setup_entry: None,
+) -> None:
+    """Test selecting absolute priority during initial setup."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            "name": "Unmixed Manifold",
+            "dhw_active_entity": "binary_sensor.dhw_active",
+            "dhw_priority": DHWPriority.ABSOLUTE.value,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"]["dhw_priority"] == DHWPriority.ABSOLUTE.value

--- a/tests/config/test_config_flow_zone.py
+++ b/tests/config/test_config_flow_zone.py
@@ -546,6 +546,7 @@ def test_get_timing_schema_with_custom() -> None:
         "window_block_time": 900,
         "controller_loop_interval": 60,
         "flush_duration": 600,
+        "dhw_recovery_time": 420,
     }
     schema = get_timing_schema(custom_timing)
 

--- a/tests/config/test_entity_unavailability.py
+++ b/tests/config/test_entity_unavailability.py
@@ -4,7 +4,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from sqlalchemy.exc import OperationalError
@@ -15,6 +15,7 @@ from custom_components.ufh_controller.const import (
     DEFAULT_TIMING,
     DOMAIN,
     SUBENTRY_TYPE_ZONE,
+    DHWPriority,
     SummerMode,
 )
 
@@ -731,3 +732,32 @@ async def test_pump_request_switch_missing_no_error(
 
     coordinator = mock_config_entry_with_pump_request.runtime_data.coordinator
     assert coordinator is not None
+
+
+async def test_dhw_sensor_unavailable_holds_block_under_absolute(
+    hass: HomeAssistant,
+    mock_config_entry_with_dhw: MockConfigEntry,
+) -> None:
+    """Test absolute priority holds the block when the DHW sensor drops out."""
+    hass.states.async_set("binary_sensor.dhw_active", STATE_ON)
+    hass.states.async_set("sensor.zone1_temp", "20.5")
+
+    mock_config_entry_with_dhw.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_with_dhw.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry_with_dhw.runtime_data.coordinator
+    coordinator.controller.config.dhw_priority = DHWPriority.ABSOLUTE
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    assert coordinator.controller.state.dhw_block is True
+
+    # Sensor drops out mid-charge - must not read as "DHW finished"
+    hass.states.async_set("binary_sensor.dhw_active", STATE_UNAVAILABLE)
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.controller.state.dhw_active is True
+    assert coordinator.controller.state.dhw_block is True
+    assert coordinator.controller.state.dhw_block_until is None
+    assert coordinator.controller.state.dhw_sensor_available is False

--- a/tests/config/test_entity_unavailability.py
+++ b/tests/config/test_entity_unavailability.py
@@ -15,6 +15,7 @@ from custom_components.ufh_controller.const import (
     DEFAULT_TIMING,
     DOMAIN,
     SUBENTRY_TYPE_ZONE,
+    ControllerStatus,
     DHWPriority,
     SummerMode,
 )
@@ -741,6 +742,7 @@ async def test_dhw_sensor_unavailable_holds_block_under_absolute(
     """Test absolute priority holds the block when the DHW sensor drops out."""
     hass.states.async_set("binary_sensor.dhw_active", STATE_ON)
     hass.states.async_set("sensor.zone1_temp", "20.5")
+    hass.states.async_set("switch.zone1_valve", "off")
 
     mock_config_entry_with_dhw.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry_with_dhw.entry_id)
@@ -757,7 +759,47 @@ async def test_dhw_sensor_unavailable_holds_block_under_absolute(
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 
-    assert coordinator.controller.state.dhw_active is True
+    assert coordinator.controller.state.dhw_sensor_fault is True
     assert coordinator.controller.state.dhw_block is True
     assert coordinator.controller.state.dhw_block_until is None
     assert coordinator.controller.state.dhw_sensor_available is False
+    assert coordinator.controller.status == ControllerStatus.DEGRADED
+
+
+async def test_dhw_sensor_missing_entirely_faults_under_absolute(
+    hass: HomeAssistant,
+    mock_config_entry_with_dhw: MockConfigEntry,
+) -> None:
+    """Test a configured DHW entity that does not exist is treated as a fault."""
+    hass.states.async_set("sensor.zone1_temp", "20.5")
+
+    mock_config_entry_with_dhw.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_with_dhw.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry_with_dhw.runtime_data.coordinator
+    coordinator.controller.config.dhw_priority = DHWPriority.ABSOLUTE
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.controller.state.dhw_sensor_fault is True
+    assert coordinator.controller.state.dhw_block is True
+
+
+async def test_dhw_fault_does_not_trip_during_initializing(
+    hass: HomeAssistant,
+    mock_config_entry_with_dhw: MockConfigEntry,
+) -> None:
+    """Test the fault does not raise status while entities are still pending."""
+    mock_config_entry_with_dhw.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_with_dhw.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry_with_dhw.runtime_data.coordinator
+    coordinator.controller.config.dhw_priority = DHWPriority.ABSOLUTE
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # The fault is recorded, but INITIALIZING is not escalated out of
+    assert coordinator.controller.state.dhw_sensor_fault is True
+    assert coordinator.controller.status == ControllerStatus.INITIALIZING

--- a/tests/config/test_translations.py
+++ b/tests/config/test_translations.py
@@ -1,0 +1,72 @@
+"""
+Tests that config flow fields and selectors resolve to translated strings.
+
+A field whose key is missing from strings.json renders with a blank label in
+the UI, which the schema tests cannot catch because the schema itself is valid.
+"""
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.translation import async_get_translations
+
+from custom_components.ufh_controller.config_flow import CONF_DHW_PRIORITY
+from custom_components.ufh_controller.const import DEFAULT_TIMING, DHWPriority
+
+PREFIX = "component.ufh_controller"
+
+CONTROL_ENTITY_FIELDS = [
+    "pump_request_entity",
+    "heat_request_entity",
+    "dhw_active_entity",
+    CONF_DHW_PRIORITY,
+    "summer_mode_entity",
+]
+
+
+@pytest.mark.parametrize("field", CONTROL_ENTITY_FIELDS)
+async def test_initial_setup_fields_have_labels(
+    hass: HomeAssistant, field: str
+) -> None:
+    """Every field in the initial setup step renders with a label."""
+    tr = await async_get_translations(
+        hass, "en", "config", integrations=["ufh_controller"]
+    )
+    assert tr.get(f"{PREFIX}.config.step.user.data.{field}")
+
+
+@pytest.mark.parametrize("field", CONTROL_ENTITY_FIELDS)
+async def test_control_entities_fields_have_labels(
+    hass: HomeAssistant, field: str
+) -> None:
+    """Every field in the Control Entities options step renders with a label."""
+    tr = await async_get_translations(
+        hass, "en", "options", integrations=["ufh_controller"]
+    )
+    assert tr.get(f"{PREFIX}.options.step.control_entities.data.{field}")
+
+
+@pytest.mark.parametrize("field", list(DEFAULT_TIMING))
+async def test_timing_fields_have_labels(hass: HomeAssistant, field: str) -> None:
+    """Every timing parameter renders with a label in both timing forms."""
+    tr = await async_get_translations(
+        hass, "en", "options", integrations=["ufh_controller"]
+    )
+    assert tr.get(f"{PREFIX}.options.step.timing.data.{field}")
+
+    subentry = await async_get_translations(
+        hass, "en", "config_subentries", integrations=["ufh_controller"]
+    )
+    assert subentry.get(
+        f"{PREFIX}.config_subentries.controller.step.reconfigure.data.{field}"
+    )
+
+
+@pytest.mark.parametrize("priority", list(DHWPriority))
+async def test_dhw_priority_options_have_labels(
+    hass: HomeAssistant, priority: DHWPriority
+) -> None:
+    """Each DHW priority dropdown option resolves via its translation_key."""
+    tr = await async_get_translations(
+        hass, "en", "selector", integrations=["ufh_controller"]
+    )
+    assert tr.get(f"{PREFIX}.selector.{CONF_DHW_PRIORITY}.options.{priority.value}")

--- a/tests/integration/test_binary_sensor.py
+++ b/tests/integration/test_binary_sensor.py
@@ -8,7 +8,11 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.ufh_controller.const import FAIL_SAFE_TIMEOUT, ZoneStatus
+from custom_components.ufh_controller.const import (
+    FAIL_SAFE_TIMEOUT,
+    DHWPriority,
+    ZoneStatus,
+)
 
 
 @pytest.fixture
@@ -357,3 +361,105 @@ async def test_flush_request_on_during_post_dhw_period(
     state = hass.states.get("binary_sensor.test_controller_flush_request")
     assert state is not None
     assert state.state == "on"
+
+
+async def test_dhw_block_binary_sensor_created_with_dhw(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test dhw_block binary sensor is created when DHW entity is configured."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_controller_dhw_block")
+    assert state is not None
+
+
+async def test_dhw_block_not_created_without_dhw(
+    hass: HomeAssistant,
+    mock_config_entry_no_zones: MockConfigEntry,
+) -> None:
+    """Test dhw_block sensor is NOT created when DHW entity is not configured."""
+    mock_config_entry_no_zones.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_no_zones.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_controller_dhw_block")
+    assert state is None
+
+
+async def test_dhw_block_off_under_partial_priority(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_temp_sensor: None,
+) -> None:
+    """Test dhw_block stays OFF during DHW when priority is partial."""
+    hass.states.async_set("binary_sensor.dhw_active", "on")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_controller_dhw_block")
+    assert state is not None
+    assert state.state == "off"
+    assert state.attributes["dhw_priority"] == DHWPriority.PARTIAL.value
+    assert state.attributes["dhw_active"] is True
+    assert state.attributes["dhw_block_until"] is None
+
+
+async def test_dhw_block_on_under_absolute_priority(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_temp_sensor: None,
+) -> None:
+    """Test dhw_block reports ON during DHW when priority is absolute."""
+    hass.states.async_set("binary_sensor.dhw_active", "on")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+    coordinator.controller.config.dhw_priority = DHWPriority.ABSOLUTE
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_controller_dhw_block")
+    assert state is not None
+    assert state.state == "on"
+    assert state.attributes["dhw_priority"] == DHWPriority.ABSOLUTE.value
+
+
+async def test_dhw_block_exposes_hold_off_expiry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_temp_sensor: None,
+) -> None:
+    """Test dhw_block_until is serialised once the hold-off is armed."""
+    hass.states.async_set("binary_sensor.dhw_active", "on")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+    coordinator.controller.config.dhw_priority = DHWPriority.ABSOLUTE
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    hass.states.async_set("binary_sensor.dhw_active", "off")
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_controller_dhw_block")
+    assert state is not None
+    assert state.state == "on"
+    block_until = state.attributes["dhw_block_until"]
+    assert block_until is not None
+    assert datetime.fromisoformat(block_until) > datetime.now(UTC)

--- a/tests/integration/test_binary_sensor.py
+++ b/tests/integration/test_binary_sensor.py
@@ -463,3 +463,49 @@ async def test_dhw_block_exposes_hold_off_expiry(
     block_until = state.attributes["dhw_block_until"]
     assert block_until is not None
     assert datetime.fromisoformat(block_until) > datetime.now(UTC)
+
+
+async def test_status_reports_dhw_fault_reason(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_temp_sensor: None,
+) -> None:
+    """Test the status sensor distinguishes a DHW fault from zone failures."""
+    hass.states.async_set("binary_sensor.dhw_active", STATE_UNAVAILABLE)
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+    coordinator.controller.config.dhw_priority = DHWPriority.ABSOLUTE
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_controller_status")
+    assert state is not None
+    assert state.state == "on"
+    assert state.attributes["fail_safe_reason"] == "dhw_sensor_unavailable"
+    # Every zone is healthy, which is exactly why the reason is needed
+    assert state.attributes["zones_fail_safe"] == 0
+
+
+async def test_status_reports_no_reason_when_normal(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_temp_sensor: None,
+) -> None:
+    """Test fail_safe_reason is absent while the controller is healthy."""
+    hass.states.async_set("binary_sensor.dhw_active", "off")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_controller_status")
+    assert state is not None
+    assert state.attributes["fail_safe_reason"] is None

--- a/tests/scenarios/test_dhw_absolute_priority.py
+++ b/tests/scenarios/test_dhw_absolute_priority.py
@@ -148,7 +148,7 @@ async def test_latent_heat_capture_is_deferred_not_cancelled() -> None:
     controller = build_controller()
     controller.state.flush_enabled = True
 
-    # Regular zone has met its quota, so it will not compete with the flush
+    # Both zones start with quota met, so nothing competes with the flush
     demand_zone(controller, "living_room", duty_cycle=0.0, valve_position=0.0)
     demand_zone(controller, "bathroom", duty_cycle=0.0, valve_position=0.0)
 

--- a/tests/scenarios/test_dhw_absolute_priority.py
+++ b/tests/scenarios/test_dhw_absolute_priority.py
@@ -1,0 +1,180 @@
+"""
+End-to-end DHW cycles under absolute priority.
+
+Walks a complete DHW charge from start to recovery expiry, verifying that
+circuits close, stay closed through the hold-off, that quota survives the
+interruption, and that latent heat capture is deferred rather than cancelled.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.ufh_controller.const import (
+    DHWPriority,
+    TimingConfig,
+    ValveState,
+)
+from custom_components.ufh_controller.core.controller import (
+    ControllerConfig,
+    HeatingController,
+)
+from custom_components.ufh_controller.core.zone import (
+    CircuitType,
+    ZoneAction,
+    ZoneConfig,
+)
+from tests.conftest import setup_zone_historical, setup_zone_pid
+
+NOW = datetime(2026, 2, 1, 12, 0, 0, tzinfo=UTC)
+RECOVERY = 300
+FLUSH_DURATION = 480
+DHW_DURATION = 900
+
+
+def build_controller() -> HeatingController:
+    """Create an absolute-priority controller with a regular and flush circuit."""
+    config = ControllerConfig(
+        controller_id="heating",
+        name="Heating Controller",
+        dhw_active_entity="binary_sensor.boiler_dhw",
+        dhw_priority=DHWPriority.ABSOLUTE,
+        timing=TimingConfig(
+            dhw_recovery_time=RECOVERY,
+            flush_duration=FLUSH_DURATION,
+        ),
+        zones=[
+            ZoneConfig(
+                zone_id="living_room",
+                name="Living Room",
+                temp_sensor="sensor.living_room_temp",
+                valve_switch="switch.living_room_valve",
+            ),
+            ZoneConfig(
+                zone_id="bathroom",
+                name="Bathroom",
+                temp_sensor="sensor.bathroom_temp",
+                valve_switch="switch.bathroom_valve",
+                circuit_type=CircuitType.FLUSH,
+            ),
+        ],
+    )
+    return HeatingController(config, started_at=NOW)
+
+
+def demand_zone(
+    controller: HeatingController,
+    zone_id: str,
+    *,
+    duty_cycle: float,
+    valve_position: float,
+) -> None:
+    """Give a zone a PID duty cycle and matching valve/flow history."""
+    setup_zone_pid(controller, zone_id, 20.0, duty_cycle)
+    setup_zone_historical(
+        controller, zone_id, valve_position=valve_position, window=False
+    )
+    runtime = controller.get_zone_runtime(zone_id)
+    runtime.update_requested_duration(controller.config.timing.observation_period)
+    runtime.state.valve_state = (
+        ValveState.ON if valve_position >= 1.0 else ValveState.OFF
+    )
+
+
+async def test_full_dhw_cycle_closes_and_resumes() -> None:
+    """A running zone is closed for DHW plus recovery, then resumes."""
+    controller = build_controller()
+    demand_zone(controller, "living_room", duty_cycle=60.0, valve_position=1.0)
+
+    # Heating normally before DHW starts
+    controller.update_dhw_state(dhw_active=False, now=NOW)
+    actions = controller.evaluate(now=NOW)
+    assert actions.valve_actions["living_room"] == ZoneAction.STAY_ON
+
+    # DHW starts - the open circuit is commanded closed immediately
+    dhw_start = NOW + timedelta(minutes=1)
+    controller.update_dhw_state(dhw_active=True, now=dhw_start)
+    actions = controller.evaluate(now=dhw_start)
+    assert actions.valve_actions["living_room"] == ZoneAction.TURN_OFF
+    assert actions.heat_request is False
+
+    # Valve has closed; it stays closed for the rest of the charge
+    controller.get_zone_runtime("living_room").state.valve_state = ValveState.OFF
+    setup_zone_historical(controller, "living_room", valve_position=0.0, window=False)
+    mid_dhw = dhw_start + timedelta(seconds=DHW_DURATION // 2)
+    controller.update_dhw_state(dhw_active=True, now=mid_dhw)
+    actions = controller.evaluate(now=mid_dhw)
+    assert actions.valve_actions["living_room"] == ZoneAction.STAY_OFF
+
+    # DHW ends but the hold-off keeps the circuit shut
+    dhw_end = dhw_start + timedelta(seconds=DHW_DURATION)
+    controller.update_dhw_state(dhw_active=False, now=dhw_end)
+    actions = controller.evaluate(now=dhw_end)
+    assert controller.state.dhw_block is True
+    assert actions.valve_actions["living_room"] == ZoneAction.STAY_OFF
+
+    still_hot = dhw_end + timedelta(seconds=RECOVERY - 30)
+    controller.update_dhw_state(dhw_active=False, now=still_hot)
+    actions = controller.evaluate(now=still_hot)
+    assert actions.valve_actions["living_room"] == ZoneAction.STAY_OFF
+
+    # Hold-off expires and normal scheduling resumes
+    resumed = dhw_end + timedelta(seconds=RECOVERY + 30)
+    controller.update_dhw_state(dhw_active=False, now=resumed)
+    actions = controller.evaluate(now=resumed)
+    assert controller.state.dhw_block is False
+    assert actions.valve_actions["living_room"] == ZoneAction.TURN_ON
+
+
+async def test_quota_survives_the_interruption() -> None:
+    """Quota is preserved while closed, so the zone catches up afterwards."""
+    controller = build_controller()
+    demand_zone(controller, "living_room", duty_cycle=60.0, valve_position=0.0)
+    runtime = controller.get_zone_runtime("living_room")
+    remaining_before = runtime.state.remaining_duration
+    assert remaining_before > 0
+
+    controller.update_dhw_state(dhw_active=True, now=NOW)
+    for step in range(1, 6):
+        moment = NOW + timedelta(seconds=60 * step)
+        controller.update_dhw_state(dhw_active=True, now=moment)
+        controller.evaluate(now=moment)
+        runtime.update_used_duration(60.0)
+
+    assert runtime.state.used_duration == 0.0
+    assert runtime.state.remaining_duration == remaining_before
+
+
+async def test_latent_heat_capture_is_deferred_not_cancelled() -> None:
+    """The flush window opens after the hold-off, at its full duration."""
+    controller = build_controller()
+    controller.state.flush_enabled = True
+
+    # Regular zone has met its quota, so it will not compete with the flush
+    demand_zone(controller, "living_room", duty_cycle=0.0, valve_position=0.0)
+    demand_zone(controller, "bathroom", duty_cycle=0.0, valve_position=0.0)
+
+    controller.update_dhw_state(dhw_active=True, now=NOW)
+    dhw_end = NOW + timedelta(seconds=DHW_DURATION)
+    controller.update_dhw_state(dhw_active=False, now=dhw_end)
+
+    # Still blocked - capturing now would push DHW-temperature water into a floor
+    during_recovery = dhw_end + timedelta(seconds=RECOVERY - 30)
+    controller.update_dhw_state(dhw_active=False, now=during_recovery)
+    actions = controller.evaluate(now=during_recovery)
+    assert actions.flush_request is False
+    assert actions.valve_actions["bathroom"] == ZoneAction.STAY_OFF
+
+    # Hold-off expired - the deferred flush window opens
+    after_recovery = dhw_end + timedelta(seconds=RECOVERY + 30)
+    controller.update_dhw_state(dhw_active=False, now=after_recovery)
+    actions = controller.evaluate(now=after_recovery)
+    assert actions.flush_request is True
+    assert actions.valve_actions["bathroom"] == ZoneAction.TURN_ON
+
+    # The full configured duration is available, not a truncated remainder
+    near_end = dhw_end + timedelta(seconds=RECOVERY + FLUSH_DURATION - 30)
+    controller.update_dhw_state(dhw_active=False, now=near_end)
+    assert controller.evaluate(now=near_end).flush_request is True
+
+    expired = dhw_end + timedelta(seconds=RECOVERY + FLUSH_DURATION + 30)
+    controller.update_dhw_state(dhw_active=False, now=expired)
+    assert controller.evaluate(now=expired).flush_request is False

--- a/tests/scenarios/test_dhw_absolute_priority.py
+++ b/tests/scenarios/test_dhw_absolute_priority.py
@@ -8,6 +8,10 @@ interruption, and that latent heat capture is deferred rather than cancelled.
 
 from datetime import UTC, datetime, timedelta
 
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from custom_components.ufh_controller.const import (
     DHWPriority,
     TimingConfig,
@@ -178,3 +182,78 @@ async def test_latent_heat_capture_is_deferred_not_cancelled() -> None:
     expired = dhw_end + timedelta(seconds=RECOVERY + FLUSH_DURATION + 30)
     controller.update_dhw_state(dhw_active=False, now=expired)
     assert controller.evaluate(now=expired).flush_request is False
+
+
+async def test_hold_off_survives_config_reload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_temp_sensor: None,
+) -> None:
+    """An in-place config reload must not release circuits early."""
+    hass.states.async_set("binary_sensor.dhw_active", STATE_ON)
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+    coordinator.controller.config.dhw_priority = DHWPriority.ABSOLUTE
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    assert coordinator.controller.state.dhw_block is True
+
+    # DHW ends - the recovery hold-off is armed
+    hass.states.async_set("binary_sensor.dhw_active", STATE_OFF)
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    assert coordinator.controller.state.dhw_block is True
+    armed_until = coordinator.controller.state.dhw_block_until
+    assert armed_until is not None
+
+    # A parameter change mid-recovery rebuilds the controller in place
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        data={**mock_config_entry.data, "dhw_priority": DHWPriority.ABSOLUTE.value},
+    )
+    await coordinator.async_reload_config()
+    await hass.async_block_till_done()
+
+    assert coordinator.controller.state.dhw_block is True
+    assert coordinator.controller.state.dhw_block_until == armed_until
+
+
+async def test_hold_off_survives_restart(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_temp_sensor: None,
+) -> None:
+    """A restart mid-recovery restores the deadline from storage."""
+    hass.states.async_set("binary_sensor.dhw_active", STATE_OFF)
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data.coordinator
+    deadline = datetime.now(UTC) + timedelta(seconds=RECOVERY)
+    stored = {
+        "dhw_active": False,
+        "dhw_block": True,
+        "dhw_block_until": deadline.isoformat(),
+    }
+
+    coordinator.controller.config.dhw_priority = DHWPriority.ABSOLUTE
+    coordinator._restore_controller_state(stored)
+
+    assert coordinator.controller.state.dhw_block is True
+    assert coordinator.controller.state.dhw_block_until == deadline
+
+    # The restored deadline still governs the next recompute
+    coordinator.controller.update_dhw_state(
+        dhw_active=False, now=deadline - timedelta(seconds=1)
+    )
+    assert coordinator.controller.state.dhw_block is True
+    coordinator.controller.update_dhw_state(
+        dhw_active=False, now=deadline + timedelta(seconds=1)
+    )
+    assert coordinator.controller.state.dhw_block is False

--- a/tests/scenarios/test_dhw_absolute_priority.py
+++ b/tests/scenarios/test_dhw_absolute_priority.py
@@ -8,13 +8,18 @@ capture is deferred rather than cancelled.
 """
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ufh_controller.const import (
+    DEFAULT_TIMING,
+    DOMAIN,
+    SUBENTRY_TYPE_ZONE,
     DHWPriority,
+    OperationMode,
     TimingConfig,
     ValveState,
 )
@@ -27,12 +32,55 @@ from custom_components.ufh_controller.core.zone import (
     ZoneAction,
     ZoneConfig,
 )
-from tests.conftest import setup_zone_historical, setup_zone_pid
+from tests.conftest import (
+    MOCK_CONTROLLER_ID,
+    MOCK_ZONE_DATA,
+    setup_zone_historical,
+    setup_zone_pid,
+)
 
 NOW = datetime(2026, 2, 1, 12, 0, 0, tzinfo=UTC)
 RECOVERY = 300
 FLUSH_DURATION = 480
 DHW_DURATION = 900
+
+
+def absolute_entry(
+    *,
+    dhw_entity: str | None = "binary_sensor.dhw_active",
+    priority: DHWPriority = DHWPriority.ABSOLUTE,
+) -> MockConfigEntry:
+    """
+    Build an entry carrying dhw_priority in entry data.
+
+    Set through entry data rather than by mutating controller.config, so
+    _parse_dhw_priority and the CONF_DHW_PRIORITY wiring are exercised.
+    """
+    timing = dict(DEFAULT_TIMING)
+    timing["dhw_recovery_time"] = RECOVERY
+    timing["flush_duration"] = FLUSH_DURATION
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Controller",
+        data={
+            "name": "Test Controller",
+            "controller_id": MOCK_CONTROLLER_ID,
+            "dhw_active_entity": dhw_entity,
+            "dhw_priority": priority.value,
+        },
+        options={"timing": timing},
+        entry_id="test_entry_dhw_scenarios",
+        unique_id=MOCK_CONTROLLER_ID,
+        subentries_data=[
+            {
+                "data": MOCK_ZONE_DATA,
+                "subentry_id": "subentry_zone1",
+                "subentry_type": SUBENTRY_TYPE_ZONE,
+                "title": "Test Zone 1",
+                "unique_id": "zone1",
+            }
+        ],
+    )
 
 
 def build_controller() -> HeatingController:
@@ -244,36 +292,129 @@ async def test_hold_off_survives_config_reload(
 
 async def test_hold_off_survives_restart(
     hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
     mock_temp_sensor: None,
 ) -> None:
-    """A restart mid-recovery restores the deadline from storage."""
+    """
+    A restart mid-recovery restores the deadline through real storage.
+
+    Goes through Store.async_load and entry setup rather than calling
+    _restore_controller_state directly, so a serialisation or storage-version
+    regression is caught.
+    """
     hass.states.async_set("binary_sensor.dhw_active", STATE_OFF)
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data.coordinator
     deadline = datetime.now(UTC) + timedelta(seconds=RECOVERY)
     stored = {
-        "dhw_active": False,
-        "dhw_block": True,
-        "dhw_block_until": deadline.isoformat(),
+        "controller": {
+            "mode": OperationMode.HEAT.value,
+            "dhw_block_until": deadline.isoformat(),
+        },
+        "zones": {},
     }
 
-    coordinator.controller.config.dhw_priority = DHWPriority.ABSOLUTE
-    coordinator._restore_controller_state(stored)
+    entry = absolute_entry()
+    with patch("homeassistant.helpers.storage.Store.async_load", return_value=stored):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
-    assert coordinator.controller.state.dhw_block is True
+    coordinator = entry.runtime_data.coordinator
     assert coordinator.controller.state.dhw_block_until == deadline
-
-    # The restored deadline still governs the next recompute
-    coordinator.controller.update_dhw_state(
-        dhw_active=False, now=deadline - timedelta(seconds=1)
-    )
     assert coordinator.controller.state.dhw_block is True
-    coordinator.controller.update_dhw_state(
-        dhw_active=False, now=deadline + timedelta(seconds=1)
-    )
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_flush_window_survives_restart(
+    hass: HomeAssistant,
+    mock_temp_sensor: None,
+) -> None:
+    """The post-DHW flush deadline is restored too, not just the block."""
+    hass.states.async_set("binary_sensor.dhw_active", STATE_OFF)
+    deadline = datetime.now(UTC) + timedelta(seconds=FLUSH_DURATION)
+    stored = {
+        "controller": {
+            "mode": OperationMode.HEAT.value,
+            "flush_until": deadline.isoformat(),
+        },
+        "zones": {},
+    }
+
+    entry = absolute_entry()
+    with patch("homeassistant.helpers.storage.Store.async_load", return_value=stored):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.coordinator
+    assert coordinator.controller.state.flush_until == deadline
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_stale_dhw_block_is_not_restored(
+    hass: HomeAssistant,
+    mock_temp_sensor: None,
+) -> None:
+    """
+    A stale dhw_block in storage must not strand the controller.
+
+    dhw_block is only recomputed by update_dhw_state, which is skipped when no
+    DHW sensor is configured, so restoring it would close every valve forever
+    under any priority.
+    """
+    stored = {
+        "controller": {
+            "mode": OperationMode.HEAT.value,
+            "dhw_block": True,
+            "dhw_active": True,
+        },
+        "zones": {},
+    }
+
+    entry = absolute_entry(dhw_entity=None, priority=DHWPriority.PARTIAL)
+    with patch("homeassistant.helpers.storage.Store.async_load", return_value=stored):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.coordinator
     assert coordinator.controller.state.dhw_block is False
+    assert coordinator.controller.state.dhw_active is False
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_restart_does_not_synthesise_end_of_charge(
+    hass: HomeAssistant,
+    mock_temp_sensor: None,
+) -> None:
+    """
+    A mid-charge save meeting an off sensor must not arm the flush window.
+
+    Restoring dhw_active would make the edge detector see ON->OFF for a charge
+    that had already finished, opening a flush circuit into a cold primary.
+    """
+    hass.states.async_set("binary_sensor.dhw_active", STATE_OFF)
+    stored = {
+        "controller": {
+            "mode": OperationMode.HEAT.value,
+            "dhw_active": True,
+            "flush_enabled": True,
+        },
+        "zones": {},
+    }
+
+    entry = absolute_entry(priority=DHWPriority.PARTIAL)
+    with patch("homeassistant.helpers.storage.Store.async_load", return_value=stored):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.coordinator
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.controller.state.flush_until is None
+    assert coordinator.controller.state.dhw_block_until is None
+
+    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/scenarios/test_dhw_absolute_priority.py
+++ b/tests/scenarios/test_dhw_absolute_priority.py
@@ -40,8 +40,11 @@ from tests.conftest import (
 )
 
 NOW = datetime(2026, 2, 1, 12, 0, 0, tzinfo=UTC)
-RECOVERY = 300
-FLUSH_DURATION = 480
+# Deliberately not DEFAULT_TIMING's values. Matching the defaults would make a
+# configured value and a fallback indistinguishable, so the config wiring could
+# break silently while every assertion below still passed.
+RECOVERY = 180
+FLUSH_DURATION = 240
 DHW_DURATION = 900
 
 
@@ -416,5 +419,61 @@ async def test_restart_does_not_synthesise_end_of_charge(
 
     assert coordinator.controller.state.flush_until is None
     assert coordinator.controller.state.dhw_block_until is None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_configured_timing_reaches_the_controller(
+    hass: HomeAssistant,
+    mock_temp_sensor: None,
+) -> None:
+    """
+    Configured DHW timing is wired through, not silently defaulted.
+
+    The values differ from DEFAULT_TIMING on purpose: with matching values a
+    broken lookup would fall back to the same number and every other
+    assertion in this module would still pass.
+    """
+    hass.states.async_set("binary_sensor.dhw_active", STATE_OFF)
+
+    entry = absolute_entry()
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    timing = entry.runtime_data.coordinator.controller.config.timing
+    assert timing.dhw_recovery_time == RECOVERY
+    assert timing.flush_duration == FLUSH_DURATION
+    assert DEFAULT_TIMING["dhw_recovery_time"] != RECOVERY
+    assert DEFAULT_TIMING["flush_duration"] != FLUSH_DURATION
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_hold_off_uses_the_configured_recovery_time(
+    hass: HomeAssistant,
+    mock_temp_sensor: None,
+) -> None:
+    """The armed deadline reflects the configured hold-off, not the default."""
+    hass.states.async_set("binary_sensor.dhw_active", STATE_ON)
+
+    entry = absolute_entry()
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.coordinator
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    hass.states.async_set("binary_sensor.dhw_active", STATE_OFF)
+    before = datetime.now(UTC)
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    armed = coordinator.controller.state.dhw_block_until
+    assert armed is not None
+    elapsed = (armed - before).total_seconds()
+    assert RECOVERY - 5 <= elapsed <= RECOVERY + 5
 
     await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/scenarios/test_dhw_absolute_priority.py
+++ b/tests/scenarios/test_dhw_absolute_priority.py
@@ -2,8 +2,9 @@
 End-to-end DHW cycles under absolute priority.
 
 Walks a complete DHW charge from start to recovery expiry, verifying that
-circuits close, stay closed through the hold-off, that quota survives the
-interruption, and that latent heat capture is deferred rather than cancelled.
+circuits close, stay closed through the hold-off and across a reload or
+restart, that quota stops accruing once flow decays, and that latent heat
+capture is deferred rather than cancelled.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -128,23 +129,42 @@ async def test_full_dhw_cycle_closes_and_resumes() -> None:
     assert actions.valve_actions["living_room"] == ZoneAction.TURN_ON
 
 
-async def test_quota_survives_the_interruption() -> None:
-    """Quota is preserved while closed, so the zone catches up afterwards."""
+async def test_quota_stops_accruing_once_flow_decays() -> None:
+    """
+    A blocked zone is charged only for the heat it actually received.
+
+    The previous version of this test set valve_position=0.0, so flow was
+    already false and update_used_duration no-opped regardless of the block -
+    it would have passed with the whole feature removed. This one starts from
+    a zone that was genuinely running when DHW asserted.
+    """
     controller = build_controller()
-    demand_zone(controller, "living_room", duty_cycle=60.0, valve_position=0.0)
+    demand_zone(controller, "living_room", duty_cycle=60.0, valve_position=1.0)
     runtime = controller.get_zone_runtime("living_room")
     remaining_before = runtime.state.remaining_duration
     assert remaining_before > 0
+    assert runtime.state.flow is True
 
     controller.update_dhw_state(dhw_active=True, now=NOW)
+    assert (
+        controller.evaluate(now=NOW).valve_actions["living_room"] == ZoneAction.TURN_OFF
+    )
+
+    # Quota still accrues while the actuator is closing and flow reads true
+    runtime.update_used_duration(30.0)
+    charged_while_closing = runtime.state.used_duration
+    assert charged_while_closing > 0
+
+    # Once the estimated position falls below the flow threshold it stops
+    setup_zone_historical(controller, "living_room", valve_position=0.0, window=False)
     for step in range(1, 6):
         moment = NOW + timedelta(seconds=60 * step)
         controller.update_dhw_state(dhw_active=True, now=moment)
         controller.evaluate(now=moment)
         runtime.update_used_duration(60.0)
 
-    assert runtime.state.used_duration == 0.0
-    assert runtime.state.remaining_duration == remaining_before
+    assert runtime.state.used_duration == charged_while_closing
+    assert runtime.state.remaining_duration == remaining_before - charged_while_closing
 
 
 async def test_latent_heat_capture_is_deferred_not_cancelled() -> None:

--- a/tests/unit/test_dhw_priority.py
+++ b/tests/unit/test_dhw_priority.py
@@ -12,6 +12,7 @@ from custom_components.ufh_controller.const import (
     OperationMode,
     TimingConfig,
     ValveState,
+    ZoneStatus,
 )
 from custom_components.ufh_controller.coordinator import _parse_dhw_priority
 from custom_components.ufh_controller.core.controller import (
@@ -651,6 +652,25 @@ class TestDHWFaultEscalation:
         controller.update_dhw_state(dhw_active=False, now=soon, sensor_available=False)
         controller.update_status(now=soon, has_pending_entities=False)
         assert controller.status == ControllerStatus.DEGRADED
+
+    def test_pending_fault_never_downgrades_zone_fail_safe(self) -> None:
+        """
+        A DHW fault only ever raises the status, so it must not lower one.
+
+        Both escalation paths write the same field, and zone aggregation can
+        reach fail-safe while the DHW clock is still running. Reporting
+        DEGRADED there would call the controller healthier than its zones are.
+        """
+        controller = self._faulted(NOW)
+        for runtime in controller.zone_runtimes:
+            runtime.state.zone_status = ZoneStatus.FAIL_SAFE
+
+        soon = NOW + timedelta(seconds=60)
+        controller.update_dhw_state(dhw_active=False, now=soon, sensor_available=False)
+        controller.update_status(now=soon, has_pending_entities=False)
+
+        assert controller.status == ControllerStatus.FAIL_SAFE
+        assert controller.fail_safe_reason == "dhw_sensor_unavailable"
 
 
 class TestHoldOffScoping:

--- a/tests/unit/test_dhw_priority.py
+++ b/tests/unit/test_dhw_priority.py
@@ -6,6 +6,7 @@ import pytest
 
 from custom_components.ufh_controller.const import (
     DEFAULT_DHW_PRIORITY,
+    ControllerStatus,
     DHWPriority,
     OperationMode,
     TimingConfig,
@@ -16,7 +17,7 @@ from custom_components.ufh_controller.core.controller import (
     ControllerConfig,
     ControllerState,
     HeatingController,
-    resolve_dhw_active,
+    is_dhw_sensor_faulted,
 )
 from custom_components.ufh_controller.core.zone import (
     CircuitType,
@@ -444,98 +445,107 @@ class TestDHWPriorityBackwardCompatibility:
         assert actions.valve_actions["living_room"] == ZoneAction.TURN_ON
 
 
-class TestResolveDHWActive:
-    """DHW state resolution when the sensor drops out."""
+class TestIsDHWSensorFaulted:
+    """An unreadable DHW sensor is a fault only under absolute priority."""
 
     @pytest.mark.parametrize(
-        ("priority", "last_known", "expected"),
+        ("priority", "expected"),
         [
-            (DHWPriority.ABSOLUTE, True, True),
-            (DHWPriority.ABSOLUTE, False, False),
-            (DHWPriority.PARTIAL, True, False),
-            (DHWPriority.PARALLEL, True, False),
-        ],
-        ids=[
-            "absolute_holds_active",
-            "absolute_holds_inactive",
-            "partial_fails_open",
-            "parallel_fails_open",
+            (DHWPriority.ABSOLUTE, True),
+            (DHWPriority.PARTIAL, False),
+            (DHWPriority.PARALLEL, False),
         ],
     )
-    def test_unavailable_sensor(
-        self, priority: DHWPriority, last_known: bool, expected: bool
-    ) -> None:
-        """Absolute holds the last known state; others keep failing open."""
+    def test_unavailable_sensor(self, priority: DHWPriority, expected: bool) -> None:
+        """Only absolute treats an unreadable sensor as a fault."""
         assert (
-            resolve_dhw_active(
-                sensor_available=False,
-                sensor_on=False,
-                last_known=last_known,
-                priority=priority,
-            )
-            is expected
+            is_dhw_sensor_faulted(sensor_available=False, priority=priority) is expected
         )
 
     @pytest.mark.parametrize("priority", list(DHWPriority))
-    @pytest.mark.parametrize("sensor_on", [True, False])
-    def test_available_sensor_is_authoritative(
-        self, priority: DHWPriority, sensor_on: bool
-    ) -> None:
-        """A usable reading always wins, whatever was held before."""
-        assert (
-            resolve_dhw_active(
-                sensor_available=True,
-                sensor_on=sensor_on,
-                last_known=not sensor_on,
-                priority=priority,
-            )
-            is sensor_on
-        )
+    def test_available_sensor_is_never_a_fault(self, priority: DHWPriority) -> None:
+        """A usable reading is never a fault, whatever the priority."""
+        assert is_dhw_sensor_faulted(sensor_available=True, priority=priority) is False
 
 
 class TestDHWSensorLoss:
-    """The block survives a DHW sensor dropping out mid-charge."""
+    """An unreadable DHW sensor faults and blocks, rather than being inferred."""
 
-    def test_block_holds_while_sensor_unavailable(self) -> None:
-        """No spurious ON->OFF edge, so the block does not expire."""
+    def test_fault_blocks_and_freezes_timers(self) -> None:
+        """No edge detection while unreadable, so no timer is armed."""
         controller = HeatingController(
             make_config(DHWPriority.ABSOLUTE), started_at=NOW
         )
         controller.update_dhw_state(dhw_active=True, now=NOW)
         assert controller.state.dhw_block is True
 
-        # Sensor drops out; resolved state holds rather than reading as OFF
         for step in range(1, 12):
             moment = NOW + timedelta(seconds=60 * step)
-            held = resolve_dhw_active(
-                sensor_available=False,
-                sensor_on=False,
-                last_known=controller.state.dhw_active,
-                priority=controller.config.dhw_priority,
-            )
             controller.update_dhw_state(
-                dhw_active=held, now=moment, sensor_available=False
+                dhw_active=False, now=moment, sensor_available=False
             )
 
-        # Well past the hold-off, but DHW never actually ended
+        # Well past the hold-off duration, but no edge was ever detected
+        assert controller.state.dhw_sensor_fault is True
+        assert controller.state.dhw_sensor_fault_since == NOW + timedelta(seconds=60)
         assert controller.state.dhw_block is True
         assert controller.state.dhw_block_until is None
+        assert controller.state.flush_until is None
         assert controller.state.dhw_sensor_available is False
 
-    def test_block_releases_normally_once_sensor_returns(self) -> None:
-        """Recovery runs from the real DHW end, not the dropout."""
+    def test_fault_blocks_even_when_last_known_was_off(self) -> None:
+        """The block does not depend on what the sensor last said."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.update_dhw_state(dhw_active=False, now=NOW)
+        assert controller.state.dhw_block is False
+
+        controller.update_dhw_state(
+            dhw_active=False,
+            now=NOW + timedelta(seconds=60),
+            sensor_available=False,
+        )
+        assert controller.state.dhw_block is True
+
+    def test_fault_raises_controller_status_to_degraded(self) -> None:
+        """A live fault is surfaced through the controller status."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.update_dhw_state(dhw_active=False, now=NOW, sensor_available=False)
+        controller.update_status(now=NOW, has_pending_entities=False)
+        assert controller.status == ControllerStatus.DEGRADED
+
+    @pytest.mark.parametrize("priority", [DHWPriority.PARTIAL, DHWPriority.PARALLEL])
+    def test_non_absolute_priorities_do_not_fault(self, priority: DHWPriority) -> None:
+        """Historical fail-open behaviour is unchanged where damage is not at stake."""
+        controller = HeatingController(make_config(priority), started_at=NOW)
+        controller.update_dhw_state(dhw_active=False, now=NOW, sensor_available=False)
+        controller.update_status(now=NOW, has_pending_entities=False)
+
+        assert controller.state.dhw_sensor_fault is False
+        assert controller.state.dhw_block is False
+        assert controller.status != ControllerStatus.DEGRADED
+
+    def test_recovery_is_timed_from_when_the_sensor_returns(self) -> None:
+        """The hold-off starts when visibility is regained, not at the dropout."""
         controller = HeatingController(
             make_config(DHWPriority.ABSOLUTE), started_at=NOW
         )
         controller.update_dhw_state(dhw_active=True, now=NOW)
 
         outage = NOW + timedelta(minutes=5)
-        controller.update_dhw_state(dhw_active=True, now=outage, sensor_available=False)
+        controller.update_dhw_state(
+            dhw_active=False, now=outage, sensor_available=False
+        )
+        assert controller.state.dhw_block_until is None
 
         returned = NOW + timedelta(minutes=10)
         controller.update_dhw_state(
             dhw_active=False, now=returned, sensor_available=True
         )
+        assert controller.state.dhw_sensor_fault is False
         assert controller.state.dhw_block_until == returned + timedelta(
             seconds=RECOVERY
         )

--- a/tests/unit/test_dhw_priority.py
+++ b/tests/unit/test_dhw_priority.py
@@ -14,6 +14,7 @@ from custom_components.ufh_controller.core.controller import (
     ControllerConfig,
     ControllerState,
     HeatingController,
+    resolve_dhw_active,
 )
 from custom_components.ufh_controller.core.zone import (
     CircuitType,
@@ -430,3 +431,105 @@ class TestDHWPriorityBackwardCompatibility:
 
         actions = controller.evaluate(now=NOW)
         assert actions.valve_actions["living_room"] == ZoneAction.TURN_ON
+
+
+class TestResolveDHWActive:
+    """DHW state resolution when the sensor drops out."""
+
+    @pytest.mark.parametrize(
+        ("priority", "last_known", "expected"),
+        [
+            (DHWPriority.ABSOLUTE, True, True),
+            (DHWPriority.ABSOLUTE, False, False),
+            (DHWPriority.PARTIAL, True, False),
+            (DHWPriority.PARALLEL, True, False),
+        ],
+        ids=[
+            "absolute_holds_active",
+            "absolute_holds_inactive",
+            "partial_fails_open",
+            "parallel_fails_open",
+        ],
+    )
+    def test_unavailable_sensor(
+        self, priority: DHWPriority, last_known: bool, expected: bool
+    ) -> None:
+        """Absolute holds the last known state; others keep failing open."""
+        assert (
+            resolve_dhw_active(
+                sensor_available=False,
+                sensor_on=False,
+                last_known=last_known,
+                priority=priority,
+            )
+            is expected
+        )
+
+    @pytest.mark.parametrize("priority", list(DHWPriority))
+    @pytest.mark.parametrize("sensor_on", [True, False])
+    def test_available_sensor_is_authoritative(
+        self, priority: DHWPriority, sensor_on: bool
+    ) -> None:
+        """A usable reading always wins, whatever was held before."""
+        assert (
+            resolve_dhw_active(
+                sensor_available=True,
+                sensor_on=sensor_on,
+                last_known=not sensor_on,
+                priority=priority,
+            )
+            is sensor_on
+        )
+
+
+class TestDHWSensorLoss:
+    """The block survives a DHW sensor dropping out mid-charge."""
+
+    def test_block_holds_while_sensor_unavailable(self) -> None:
+        """No spurious ON->OFF edge, so the block does not expire."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        assert controller.state.dhw_block is True
+
+        # Sensor drops out; resolved state holds rather than reading as OFF
+        for step in range(1, 12):
+            moment = NOW + timedelta(seconds=60 * step)
+            held = resolve_dhw_active(
+                sensor_available=False,
+                sensor_on=False,
+                last_known=controller.state.dhw_active,
+                priority=controller.config.dhw_priority,
+            )
+            controller.update_dhw_state(
+                dhw_active=held, now=moment, sensor_available=False
+            )
+
+        # Well past the hold-off, but DHW never actually ended
+        assert controller.state.dhw_block is True
+        assert controller.state.dhw_block_until is None
+        assert controller.state.dhw_sensor_available is False
+
+    def test_block_releases_normally_once_sensor_returns(self) -> None:
+        """Recovery runs from the real DHW end, not the dropout."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+
+        outage = NOW + timedelta(minutes=5)
+        controller.update_dhw_state(dhw_active=True, now=outage, sensor_available=False)
+
+        returned = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(
+            dhw_active=False, now=returned, sensor_available=True
+        )
+        assert controller.state.dhw_block_until == returned + timedelta(
+            seconds=RECOVERY
+        )
+
+        after = returned + timedelta(seconds=RECOVERY + 1)
+        controller.update_dhw_state(dhw_active=False, now=after)
+        assert controller.state.dhw_block is False
+        assert controller.state.dhw_sensor_available is True

--- a/tests/unit/test_dhw_priority.py
+++ b/tests/unit/test_dhw_priority.py
@@ -1,0 +1,432 @@
+"""Test DHW priority levels and the absolute-priority block."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from custom_components.ufh_controller.const import (
+    DHWPriority,
+    OperationMode,
+    TimingConfig,
+    ValveState,
+)
+from custom_components.ufh_controller.core.controller import (
+    ControllerConfig,
+    ControllerState,
+    HeatingController,
+)
+from custom_components.ufh_controller.core.zone import (
+    CircuitType,
+    ZoneAction,
+    ZoneConfig,
+    ZoneState,
+    evaluate_zone,
+)
+from tests.conftest import setup_zone_historical, setup_zone_pid
+
+NOW = datetime(2026, 2, 1, 12, 0, 0, tzinfo=UTC)
+RECOVERY = 300
+FLUSH_DURATION = 480
+
+
+def make_config(
+    priority: DHWPriority,
+    *,
+    recovery: int = RECOVERY,
+    flush_duration: int = FLUSH_DURATION,
+) -> ControllerConfig:
+    """Build a two-zone controller config with the given DHW priority."""
+    return ControllerConfig(
+        controller_id="heating",
+        name="Heating Controller",
+        dhw_active_entity="binary_sensor.boiler_dhw",
+        dhw_priority=priority,
+        timing=TimingConfig(
+            dhw_recovery_time=recovery,
+            flush_duration=flush_duration,
+        ),
+        zones=[
+            ZoneConfig(
+                zone_id="living_room",
+                name="Living Room",
+                temp_sensor="sensor.living_room_temp",
+                valve_switch="switch.living_room_valve",
+            ),
+            ZoneConfig(
+                zone_id="bathroom",
+                name="Bathroom",
+                temp_sensor="sensor.bathroom_temp",
+                valve_switch="switch.bathroom_valve",
+                circuit_type=CircuitType.FLUSH,
+            ),
+        ],
+    )
+
+
+class TestEvaluateZoneDHWBlock:
+    """The block closes every circuit and overrides every other path."""
+
+    @pytest.fixture
+    def timing(self) -> TimingConfig:
+        """Create default timing config."""
+        return TimingConfig()
+
+    @pytest.fixture
+    def blocked(self) -> ControllerState:
+        """Create controller state with the DHW block asserted."""
+        return ControllerState(started_at=NOW, dhw_block=True, dhw_active=True)
+
+    def test_running_zone_turns_off(
+        self, timing: TimingConfig, blocked: ControllerState
+    ) -> None:
+        """A zone already ON is closed, overriding the STAY_ON path."""
+        zone = ZoneState(
+            zone_id="living_room",
+            valve_state=ValveState.ON,
+            requested_duration=3600.0,
+            used_duration=0.0,
+        )
+        assert evaluate_zone(zone, blocked, timing) == ZoneAction.TURN_OFF
+
+    def test_closed_zone_stays_off(
+        self, timing: TimingConfig, blocked: ControllerState
+    ) -> None:
+        """A zone already OFF stays off without a redundant command."""
+        zone = ZoneState(
+            zone_id="living_room",
+            valve_state=ValveState.OFF,
+            requested_duration=3600.0,
+        )
+        assert evaluate_zone(zone, blocked, timing) == ZoneAction.STAY_OFF
+
+    @pytest.mark.parametrize(
+        "valve_state", [ValveState.UNKNOWN, ValveState.UNAVAILABLE]
+    )
+    def test_uncertain_valve_turns_off(
+        self,
+        timing: TimingConfig,
+        blocked: ControllerState,
+        valve_state: ValveState,
+    ) -> None:
+        """An uncertain valve state is actively driven closed."""
+        zone = ZoneState(zone_id="living_room", valve_state=valve_state)
+        assert evaluate_zone(zone, blocked, timing) == ZoneAction.TURN_OFF
+
+    def test_overrides_end_of_period_freeze(self, timing: TimingConfig) -> None:
+        """The block wins over the end-of-observation-period valve freeze."""
+        blocked = ControllerState(
+            started_at=NOW,
+            dhw_block=True,
+            dhw_active=True,
+            period_elapsed=timing.observation_period - 60,
+        )
+        zone = ZoneState(zone_id="living_room", valve_state=ValveState.ON)
+        assert evaluate_zone(zone, blocked, timing) == ZoneAction.TURN_OFF
+
+    def test_flush_circuit_under_quota_scheduling_is_blocked(
+        self, timing: TimingConfig
+    ) -> None:
+        """
+        A flush circuit with capture disabled is closed too.
+
+        The soft gate only ever covered regular circuits; the hazard the block
+        guards against is hydraulic, so it applies to every circuit type.
+        """
+        blocked = ControllerState(
+            started_at=NOW,
+            dhw_block=True,
+            dhw_active=True,
+            flush_enabled=False,
+        )
+        zone = ZoneState(
+            zone_id="bathroom",
+            circuit_type=CircuitType.FLUSH,
+            valve_state=ValveState.ON,
+            requested_duration=3600.0,
+        )
+        assert evaluate_zone(zone, blocked, timing) == ZoneAction.TURN_OFF
+
+    def test_flush_activation_is_blocked(self, timing: TimingConfig) -> None:
+        """Even an explicit flush_request cannot open a circuit while blocked."""
+        blocked = ControllerState(
+            started_at=NOW,
+            dhw_block=True,
+            flush_enabled=True,
+        )
+        zone = ZoneState(
+            zone_id="bathroom",
+            circuit_type=CircuitType.FLUSH,
+            valve_state=ValveState.OFF,
+        )
+        result = evaluate_zone(zone, blocked, timing, flush_request=True)
+        assert result == ZoneAction.STAY_OFF
+
+    def test_disabled_zone_still_short_circuits_first(
+        self, timing: TimingConfig, blocked: ControllerState
+    ) -> None:
+        """A disabled zone is closed regardless of the block."""
+        zone = ZoneState(
+            zone_id="living_room", enabled=False, valve_state=ValveState.ON
+        )
+        assert evaluate_zone(zone, blocked, timing) == ZoneAction.TURN_OFF
+
+
+class TestUpdateDHWStateTimers:
+    """Timer arithmetic across the DHW edges for each priority."""
+
+    def test_absolute_arms_hold_off_on_dhw_end(self) -> None:
+        """Block persists through the recovery window after DHW ends."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.state.flush_enabled = True
+
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        assert controller.state.dhw_block is True
+
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+        assert controller.state.dhw_block is True
+        assert controller.state.dhw_block_until == end + timedelta(seconds=RECOVERY)
+
+        controller.update_dhw_state(
+            dhw_active=False, now=end + timedelta(seconds=RECOVERY - 1)
+        )
+        assert controller.state.dhw_block is True
+
+        controller.update_dhw_state(
+            dhw_active=False, now=end + timedelta(seconds=RECOVERY + 1)
+        )
+        assert controller.state.dhw_block is False
+
+    def test_absolute_defers_flush_window_past_hold_off(self) -> None:
+        """The flush window is delayed by the recovery time, not shortened."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.state.flush_enabled = True
+
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+
+        assert controller.state.flush_until == end + timedelta(
+            seconds=RECOVERY + FLUSH_DURATION
+        )
+
+    @pytest.mark.parametrize("priority", [DHWPriority.PARTIAL, DHWPriority.PARALLEL])
+    def test_non_absolute_leaves_flush_window_unchanged(
+        self, priority: DHWPriority
+    ) -> None:
+        """Partial and parallel keep the historical flush timing exactly."""
+        controller = HeatingController(make_config(priority), started_at=NOW)
+        controller.state.flush_enabled = True
+
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+
+        assert controller.state.flush_until == end + timedelta(seconds=FLUSH_DURATION)
+        assert controller.state.dhw_block is False
+
+    def test_hold_off_armed_even_with_capture_disabled(self) -> None:
+        """The safety timer does not depend on the flush feature being on."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        assert controller.state.flush_enabled is False
+
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+
+        assert controller.state.dhw_block_until == end + timedelta(seconds=RECOVERY)
+        assert controller.state.dhw_block is True
+        assert controller.state.flush_until is None
+
+    def test_zero_recovery_clears_block_immediately(self) -> None:
+        """Recovery of zero means the block covers DHW only."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE, recovery=0), started_at=NOW
+        )
+        controller.state.flush_enabled = True
+
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+
+        assert controller.state.dhw_block is False
+        assert controller.state.flush_until == end + timedelta(seconds=FLUSH_DURATION)
+
+    def test_dhw_reasserts_during_recovery(self) -> None:
+        """A new DHW cycle clears the flush timer and re-blocks."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.state.flush_enabled = True
+
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+
+        restart = end + timedelta(seconds=60)
+        controller.update_dhw_state(dhw_active=True, now=restart)
+        assert controller.state.flush_until is None
+        assert controller.state.dhw_block is True
+
+        second_end = restart + timedelta(minutes=5)
+        controller.update_dhw_state(dhw_active=False, now=second_end)
+        assert controller.state.dhw_block_until == second_end + timedelta(
+            seconds=RECOVERY
+        )
+        assert controller.state.flush_until == second_end + timedelta(
+            seconds=RECOVERY + FLUSH_DURATION
+        )
+
+    def test_block_clears_when_priority_lowered(self) -> None:
+        """Dropping out of absolute releases an in-progress block."""
+        config = make_config(DHWPriority.ABSOLUTE)
+        controller = HeatingController(config, started_at=NOW)
+
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        assert controller.state.dhw_block is True
+
+        config.dhw_priority = DHWPriority.PARTIAL
+        controller.update_dhw_state(dhw_active=True, now=NOW + timedelta(seconds=60))
+        assert controller.state.dhw_block is False
+
+
+class TestDHWBlockModeInteraction:
+    """Mode dispatch while the block is asserted."""
+
+    @pytest.mark.parametrize(
+        "mode", [OperationMode.FLUSH, OperationMode.CYCLE, OperationMode.HEAT]
+    )
+    def test_automatic_modes_close_all_valves(self, mode: OperationMode) -> None:
+        """Heat, flush and cycle all yield closed valves and no requests."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.mode = mode
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+
+        actions = controller.evaluate(now=NOW)
+
+        assert all(
+            action in {ZoneAction.TURN_OFF, ZoneAction.STAY_OFF}
+            for action in actions.valve_actions.values()
+        )
+        assert actions.heat_request is False
+        assert not actions.pump_request
+
+    def test_flush_mode_resumes_after_block_clears(self) -> None:
+        """The mode is suspended, not cancelled."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.mode = OperationMode.FLUSH
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        assert controller.mode == OperationMode.FLUSH
+
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+        after = end + timedelta(seconds=RECOVERY + 1)
+        controller.update_dhw_state(dhw_active=False, now=after)
+
+        actions = controller.evaluate(now=after)
+        assert all(
+            action in {ZoneAction.TURN_ON, ZoneAction.STAY_ON}
+            for action in actions.valve_actions.values()
+        )
+        assert actions.pump_request is True
+
+    def test_all_on_is_not_overridden(self) -> None:
+        """Explicit manual override states user intent and is respected."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.mode = OperationMode.ALL_ON
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+
+        actions = controller.evaluate(now=NOW)
+        assert all(
+            action in {ZoneAction.TURN_ON, ZoneAction.STAY_ON}
+            for action in actions.valve_actions.values()
+        )
+
+    def test_block_and_flush_request_are_mutually_exclusive(self) -> None:
+        """The invariant that makes evaluate_zone ordering non-load-bearing."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.state.flush_enabled = True
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+
+        step = timedelta(seconds=30)
+        moment = NOW
+        saw_flush_request = False
+        while moment <= end + timedelta(seconds=RECOVERY + FLUSH_DURATION + 60):
+            controller.update_dhw_state(dhw_active=NOW <= moment < end, now=moment)
+            actions = controller.evaluate(now=moment)
+            assert not (controller.state.dhw_block and actions.flush_request)
+            saw_flush_request |= actions.flush_request
+            moment += step
+
+        # The flush window must actually open, or the invariant is vacuous
+        assert saw_flush_request is True
+
+
+class TestDHWPriorityBackwardCompatibility:
+    """Partial priority must reproduce the historical soft gate exactly."""
+
+    def test_partial_keeps_running_zone_on(self) -> None:
+        """A zone already ON continues through DHW under partial priority."""
+        controller = HeatingController(make_config(DHWPriority.PARTIAL), started_at=NOW)
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+
+        setup_zone_pid(controller, "living_room", 20.0, 60.0)
+        setup_zone_historical(
+            controller, "living_room", valve_position=1.0, window=False
+        )
+        runtime = controller.get_zone_runtime("living_room")
+        runtime.update_requested_duration(7200)
+        runtime.state.valve_state = ValveState.ON
+
+        actions = controller.evaluate(now=NOW)
+        assert actions.valve_actions["living_room"] == ZoneAction.STAY_ON
+
+    def test_partial_blocks_new_start(self) -> None:
+        """A zone that is OFF cannot start under partial priority."""
+        controller = HeatingController(make_config(DHWPriority.PARTIAL), started_at=NOW)
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+
+        setup_zone_pid(controller, "living_room", 20.0, 60.0)
+        setup_zone_historical(
+            controller, "living_room", valve_position=0.0, window=False
+        )
+        runtime = controller.get_zone_runtime("living_room")
+        runtime.update_requested_duration(7200)
+        runtime.state.valve_state = ValveState.OFF
+
+        actions = controller.evaluate(now=NOW)
+        assert actions.valve_actions["living_room"] == ZoneAction.STAY_OFF
+
+    def test_parallel_allows_new_start_during_dhw(self) -> None:
+        """Parallel priority ignores DHW entirely."""
+        controller = HeatingController(
+            make_config(DHWPriority.PARALLEL), started_at=NOW
+        )
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+
+        setup_zone_pid(controller, "living_room", 20.0, 60.0)
+        setup_zone_historical(
+            controller, "living_room", valve_position=0.0, window=False
+        )
+        runtime = controller.get_zone_runtime("living_room")
+        runtime.update_requested_duration(7200)
+        runtime.state.valve_state = ValveState.OFF
+
+        actions = controller.evaluate(now=NOW)
+        assert actions.valve_actions["living_room"] == ZoneAction.TURN_ON

--- a/tests/unit/test_dhw_priority.py
+++ b/tests/unit/test_dhw_priority.py
@@ -651,3 +651,35 @@ class TestDHWFaultEscalation:
         controller.update_dhw_state(dhw_active=False, now=soon, sensor_available=False)
         controller.update_status(now=soon, has_pending_entities=False)
         assert controller.status == ControllerStatus.DEGRADED
+
+
+class TestHoldOffScoping:
+    """The hold-off deadline exists only where a block can engage."""
+
+    @pytest.mark.parametrize("priority", [DHWPriority.PARTIAL, DHWPriority.PARALLEL])
+    def test_no_deadline_armed_without_absolute(self, priority: DHWPriority) -> None:
+        """
+        Non-absolute priorities never arm the hold-off.
+
+        Arming it regardless meant partial and parallel users saw a populated
+        "Block Until" attribute, and had it persisted, for a block that could
+        never engage.
+        """
+        controller = HeatingController(make_config(priority), started_at=NOW)
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+
+        assert controller.state.dhw_block_until is None
+        assert controller.state.dhw_block is False
+
+    def test_deadline_armed_under_absolute(self) -> None:
+        """Absolute still arms it, so the block has something to run on."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+
+        assert controller.state.dhw_block_until == end + timedelta(seconds=RECOVERY)

--- a/tests/unit/test_dhw_priority.py
+++ b/tests/unit/test_dhw_priority.py
@@ -558,3 +558,38 @@ class TestParseDHWPriority:
     def test_unusable_values_fall_back(self, value: object) -> None:
         """Missing or unrecognised values degrade instead of failing setup."""
         assert _parse_dhw_priority(value) is DEFAULT_DHW_PRIORITY
+
+
+class TestHoldOffDeadlineCleanup:
+    """The recovery deadline does not linger once it has passed."""
+
+    def test_expired_deadline_is_cleared(self) -> None:
+        """A passed deadline stops being reported as pending."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+        assert controller.state.dhw_block_until is not None
+
+        controller.update_dhw_state(
+            dhw_active=False, now=end + timedelta(seconds=RECOVERY + 1)
+        )
+        assert controller.state.dhw_block is False
+        assert controller.state.dhw_block_until is None
+
+    def test_pending_deadline_is_retained(self) -> None:
+        """A deadline still in the future is left alone."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.update_dhw_state(dhw_active=True, now=NOW)
+        end = NOW + timedelta(minutes=10)
+        controller.update_dhw_state(dhw_active=False, now=end)
+
+        controller.update_dhw_state(
+            dhw_active=False, now=end + timedelta(seconds=RECOVERY - 1)
+        )
+        assert controller.state.dhw_block is True
+        assert controller.state.dhw_block_until == end + timedelta(seconds=RECOVERY)

--- a/tests/unit/test_dhw_priority.py
+++ b/tests/unit/test_dhw_priority.py
@@ -309,6 +309,15 @@ class TestDHWBlockModeInteraction:
             make_config(DHWPriority.ABSOLUTE), started_at=NOW
         )
         controller.mode = mode
+
+        # A zone still reporting flow, so the pump assertion is load-bearing
+        setup_zone_pid(controller, "living_room", 20.0, 60.0)
+        setup_zone_historical(
+            controller, "living_room", valve_position=1.0, window=False
+        )
+        controller.get_zone_runtime("living_room").update_requested_duration(7200)
+        controller.get_zone_runtime("living_room").state.valve_state = ValveState.ON
+
         controller.update_dhw_state(dhw_active=True, now=NOW)
 
         actions = controller.evaluate(now=NOW)

--- a/tests/unit/test_dhw_priority.py
+++ b/tests/unit/test_dhw_priority.py
@@ -6,6 +6,7 @@ import pytest
 
 from custom_components.ufh_controller.const import (
     DEFAULT_DHW_PRIORITY,
+    FAIL_SAFE_TIMEOUT,
     ControllerStatus,
     DHWPriority,
     OperationMode,
@@ -603,3 +604,50 @@ class TestHoldOffDeadlineCleanup:
         )
         assert controller.state.dhw_block is True
         assert controller.state.dhw_block_until == end + timedelta(seconds=RECOVERY)
+
+
+class TestDHWFaultEscalation:
+    """A sustained DHW sensor fault escalates to controller fail-safe."""
+
+    def _faulted(self, at: datetime) -> HeatingController:
+        """Create a controller with a live DHW sensor fault."""
+        controller = HeatingController(
+            make_config(DHWPriority.ABSOLUTE), started_at=NOW
+        )
+        controller.update_dhw_state(dhw_active=False, now=at, sensor_available=False)
+        return controller
+
+    def test_stays_degraded_before_the_timeout(self) -> None:
+        """Escalation waits, matching how zone failures escalate."""
+        controller = self._faulted(NOW)
+        later = NOW + timedelta(seconds=FAIL_SAFE_TIMEOUT - 60)
+        controller.update_dhw_state(dhw_active=False, now=later, sensor_available=False)
+        controller.update_status(now=later, has_pending_entities=False)
+        assert controller.status == ControllerStatus.DEGRADED
+
+    def test_escalates_after_the_timeout(self) -> None:
+        """A persistent fault reaches fail-safe so the boiler is handed back."""
+        controller = self._faulted(NOW)
+        later = NOW + timedelta(seconds=FAIL_SAFE_TIMEOUT + 60)
+        controller.update_dhw_state(dhw_active=False, now=later, sensor_available=False)
+        controller.update_status(now=later, has_pending_entities=False)
+        assert controller.status == ControllerStatus.FAIL_SAFE
+
+    def test_recovery_before_the_timeout_never_escalates(self) -> None:
+        """A transient dropout resets the clock rather than accumulating."""
+        controller = self._faulted(NOW)
+
+        back = NOW + timedelta(seconds=60)
+        controller.update_dhw_state(dhw_active=False, now=back, sensor_available=True)
+        assert controller.state.dhw_sensor_fault is False
+        assert controller.state.dhw_sensor_fault_since is None
+
+        # A later fault starts a fresh clock, not one carried over
+        again = back + timedelta(seconds=60)
+        controller.update_dhw_state(dhw_active=False, now=again, sensor_available=False)
+        assert controller.state.dhw_sensor_fault_since == again
+
+        soon = again + timedelta(seconds=FAIL_SAFE_TIMEOUT - 60)
+        controller.update_dhw_state(dhw_active=False, now=soon, sensor_available=False)
+        controller.update_status(now=soon, has_pending_entities=False)
+        assert controller.status == ControllerStatus.DEGRADED

--- a/tests/unit/test_dhw_priority.py
+++ b/tests/unit/test_dhw_priority.py
@@ -5,11 +5,13 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from custom_components.ufh_controller.const import (
+    DEFAULT_DHW_PRIORITY,
     DHWPriority,
     OperationMode,
     TimingConfig,
     ValveState,
 )
+from custom_components.ufh_controller.coordinator import _parse_dhw_priority
 from custom_components.ufh_controller.core.controller import (
     ControllerConfig,
     ControllerState,
@@ -542,3 +544,17 @@ class TestDHWSensorLoss:
         controller.update_dhw_state(dhw_active=False, now=after)
         assert controller.state.dhw_block is False
         assert controller.state.dhw_sensor_available is True
+
+
+class TestParseDHWPriority:
+    """Stored priority values are parsed defensively."""
+
+    @pytest.mark.parametrize("priority", list(DHWPriority))
+    def test_known_values_round_trip(self, priority: DHWPriority) -> None:
+        """Every enum member parses back to itself."""
+        assert _parse_dhw_priority(priority.value) is priority
+
+    @pytest.mark.parametrize("value", [None, "", "Absolute", "aggressive", 42])
+    def test_unusable_values_fall_back(self, value: object) -> None:
+        """Missing or unrecognised values degrade instead of failing setup."""
+        assert _parse_dhw_priority(value) is DEFAULT_DHW_PRIORITY

--- a/tests/unit/test_flush_request.py
+++ b/tests/unit/test_flush_request.py
@@ -12,22 +12,32 @@ FLUSH_UNTIL_EXPIRED = "expired"
 
 
 @pytest.mark.parametrize(
-    ("flush_enabled", "dhw_active", "flush_until", "any_regular_on", "expected"),
+    (
+        "flush_enabled",
+        "dhw_active",
+        "dhw_block",
+        "flush_until",
+        "any_regular_on",
+        "expected",
+    ),
     [
         # flush_enabled=False always returns False
-        (False, False, None, False, False),
-        (False, False, FLUSH_UNTIL_FUTURE, False, False),
+        (False, False, False, None, False, False),
+        (False, False, False, FLUSH_UNTIL_FUTURE, False, False),
         # No post-DHW timer returns False (even if flush enabled)
-        (True, False, None, False, False),
+        (True, False, False, None, False, False),
         # DHW currently active returns False
-        (True, True, None, False, False),
-        (True, True, FLUSH_UNTIL_FUTURE, False, False),
+        (True, True, False, None, False, False),
+        (True, True, False, FLUSH_UNTIL_FUTURE, False, False),
         # Post-DHW period (timer active) + no regular ON = True
-        (True, False, FLUSH_UNTIL_FUTURE, False, True),
+        (True, False, False, FLUSH_UNTIL_FUTURE, False, True),
         # Post-DHW period + regular ON = False
-        (True, False, FLUSH_UNTIL_FUTURE, True, False),
+        (True, False, False, FLUSH_UNTIL_FUTURE, True, False),
         # Post-DHW period expired = False
-        (True, False, FLUSH_UNTIL_EXPIRED, False, False),
+        (True, False, False, FLUSH_UNTIL_EXPIRED, False, False),
+        # Absolute DHW priority hold-off suppresses the flush window
+        (True, False, True, FLUSH_UNTIL_FUTURE, False, False),
+        (True, True, True, FLUSH_UNTIL_FUTURE, False, False),
     ],
     ids=[
         "disabled_returns_false",
@@ -38,11 +48,14 @@ FLUSH_UNTIL_EXPIRED = "expired"
         "post_dhw_no_regular_returns_true",
         "post_dhw_regular_on_returns_false",
         "post_dhw_expired_returns_false",
+        "dhw_block_during_recovery_returns_false",
+        "dhw_block_while_dhw_active_returns_false",
     ],
 )
 def test_compute_flush_request(
     flush_enabled: bool,
     dhw_active: bool,
+    dhw_block: bool,
     flush_until: str | None,
     any_regular_on: bool,
     expected: bool,
@@ -60,6 +73,7 @@ def test_compute_flush_request(
     result = compute_flush_request(
         flush_enabled=flush_enabled,
         dhw_active=dhw_active,
+        dhw_block=dhw_block,
         flush_until=flush_until_dt,
         any_regular_on=any_regular_on,
         now=now,


### PR DESCRIPTION
Closes the gap reported in discussion #118: the current DHW handling assumes every system can tolerate concurrent DHW and underfloor heating. That holds only where a 3-way diverter or a mixing valve protects the manifold.

## The problem

`sega66` runs a boiler with two flow-temperature regimes:

| Boiler mode | Flow temp | Safe for UFH? |
|---|---|---|
| Central heating | ~45 °C | yes |
| DHW / cylinder charging | ~70 °C | **no** |

Nothing isolates or mixes the underfloor manifold, so any open zone valve during DHW puts 70 °C water into the screed — cracking, floor-covering damage (wood and vinyl want ≤27 °C surface), thermal shock.

Our `dhw_active_entity` handling was a *soft* gate: it only stopped zones that were OFF from starting. A zone already ON kept running, because `evaluate_zone` returned `STAY_ON` before the DHW check was ever reached. For this topology that is backwards.

Thanks to @sega66 for the report and the detail about the two flow setpoints, and to @krotname for tracing the current behaviour and proposing the configurable split.

## The change

A three-level `dhw_priority` setting, using the terminology that Viessmann, Vaillant, Buderus and Weishaupt all ship for exactly this (*Vorrangschaltung*):

| Value | Behaviour while DHW is active |
|---|---|
| `parallel` | No restriction. Scheduling ignores DHW entirely. |
| `partial` | **Default — today's behaviour.** Open circuits stay open, closed ones cannot start. |
| `absolute` | All circuits actively closed, for the duration of DHW **plus a recovery hold-off**. |

Existing entries have no `dhw_priority` key, fall back to `partial`, and behave identically.

Configured in **Control Entities** (initial setup and options), with `dhw_recovery_time` (default 300 s) in **Timing Parameters**. A `binary_sensor.{controller_id}_dhw_block` reports when the block is in force, with `dhw_priority` / `dhw_active` / `dhw_block_until` attributes.

## Interaction with the flush feature

This needed the most care, because the codebase overloads "flush" three ways and this touches all three.

**Post-DHW latent heat capture** is the real conflict. It and absolute priority are opposing answers to the same question — what to do with the water left in the primary when DHW finishes. Capture says "it's hot, harvest it"; absolute priority says "it's *too* hot, keep it out of the floor". Resolved by deferral rather than suppression:

```
                DHW active          recovery           flush window
   ────────────┬───────────────────┬─────────────────┬──────────────────┬──────
              DHW on            DHW off      +dhw_recovery_time   +flush_duration
   dhw_block:  ═══════════════════════════════════════╝
   flush_request:                                      ─────── possible ───────╝
```

On the normal path the configured `flush_duration` is preserved in full, just delayed. The window closes at a fixed time, though, so anything that delays its *start* eats into it rather than shifting it — if the DHW sensor drops out during the hold-off, only the remainder is used. That is the safe direction, since the delay implies the primary stayed hot longer than expected.

`compute_flush_request` returns False whenever the block is in force, which makes the two mutually exclusive *by construction* rather than by evaluation order — there is a test asserting that invariant directly across a whole cycle.

The hold-off timer is deliberately armed **outside** the `flush_enabled` condition. Putting it in the obvious place would have meant users with latent heat capture off — the default — got no recovery hold-off at all.

**Maintenance flush mode and cycle mode** build valve actions directly rather than through `evaluate_zone`, so each gets an explicit early return. This matters because the weekly 02:00 pipe flush can collide with a DHW cycle. The mode is suspended, not cancelled, and resumes when the block clears. `all_on` is left alone as an explicit manual override, consistent with `get_summer_mode_value`.

**Flush-type circuits** were never covered by the soft gate (`zone.py` checked `== CircuitType.REGULAR`). The block applies to all circuit types, since the hazard is hydraulic and a flush circuit is just as much a floor loop. The `partial` gate is left as-is to avoid changing behaviour for existing users.

## One thing the tests caught

Planning assumed heat request needed no changes: valves close → no flow → pump off → the existing safety net drops heat request. That assumed valves close instantly. They take ~3.5 minutes, so a circuit still reports flow at the instant DHW asserts, and the controller was asking the boiler to fire for space heating mid-charge. Heat request is now suppressed outright while the block is in force; pump request stays flow-driven and decays as the valves close.

## Stated limitations

Both are documented rather than papered over:

- **Valve close time.** Closure is commanded the instant DHW asserts, but the hardware needs its ~3.5 minutes. A brief exposure window is unavoidable; a diverter or mixing valve remains the better fix where one can be fitted.
- **The hold-off is a timer, not a measurement.** It makes deferred harvesting safer, not provably safe. The docs recommend leaving `flush_enabled` off on unmixed systems unless a supply temperature sensor confirms the primary has cooled. This is the argument for a future supply over-temperature cutout as a genuine backstop.

## Verification

773 tests pass; 100% diff coverage against `main`, with no partially-covered branches in the diff. New coverage spans unit tests for the block and timer arithmetic, the mutual-exclusion invariant, integration tests for the sensor and config flow round-trip, backward-compatibility assertions for `partial`/`parallel`, and an end-to-end scenario walking a full DHW cycle including quota preservation and the deferred flush window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Behaviour when the DHW sensor cannot be read

Added after review. Under `absolute`, a DHW sensor that is missing, `unavailable` or `unknown` is treated as a **fault** rather than a state to be guessed — neither "assume off" nor "assume the last known value" gives the certainty the setting exists to provide.

It escalates in two stages, matching how zone failures already escalate:

| Stage | When | Effect |
|---|---|---|
| Block | First unreadable cycle | All circuits closed, both timers frozen, status `degraded` |
| Escalation | Sustained 1 hour | Status `fail_safe`; valves closed in every mode except `off`, summer mode `auto` |

Timers freeze rather than run, because an unreadable sensor gives nothing to detect a DHW end from; inventing an edge would either arm the hold-off from a charge that hasn't ended or release one that should still be running. When the sensor returns, recovery is timed from when visibility was regained.

`parallel` and `partial` keep the historical fail-open behaviour and never raise this fault, so existing installations are unaffected.

**Residual risk, stated plainly:** while the sensor is unreadable there is no heating at all. That's deliberate — the DHW hazard is chosen over the freeze hazard — and note that `summer_mode=auto` at escalation does *not* soften it, since the controller keeps every valve shut. The `status` sensor reports a problem from the first blocked cycle, with a `fail_safe_reason` attribute naming the cause (a DHW fault reaches fail-safe with every zone healthy, so `zones_fail_safe` reads 0).

## State persistence

Only the two deadlines that cannot be reconstructed are persisted and restored: `dhw_block_until` and `flush_until`. Everything else is derived and recomputed from live inputs on the first cycle.

An earlier round persisted `dhw_active` and `dhw_block` too, which caused two regressions caught by review: a restored `dhw_block` stranded the controller permanently when no DHW sensor was configured (nothing recomputes it on that path, and `evaluate_zone` gates on it without re-checking priority), and a restored `dhw_active` synthesised a false end-of-charge that armed the flush window into a cold primary. Both are covered by regression tests verified to fail without the fix.

