### PR TITLE
Let dependabot track pytest-homeassistant-custom-component

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
       - dependency-name: "homeassistant"
-      - dependency-name: "pytest-homeassistant-custom-component"
       - dependency-name: "pytest"
       - dependency-name: "pytest-asyncio"
       - dependency-name: "pytest-cov"


### PR DESCRIPTION
Removes `pytest-homeassistant-custom-component` from the dependabot ignore list so the weekly schedule bumps it, and CI runs against current Home Assistant instead of the version pinned in March.

`homeassistant`, `pytest`, `pytest-asyncio` and `pytest-cov` stay ignored — phcc pins all of them exactly, so they move with the phcc bump.

Config change only; the pin itself is untouched.