### PR TITLE
Let phcc own the Home Assistant test stack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,21 +15,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    versioning-strategy: increase-if-necessary
     groups:
       home-assistant-test-stack:
         patterns:
           - "pytest-homeassistant-custom-component"
-          - "homeassistant"
-          - "pytest"
-          - "pytest-asyncio"
-          - "pytest-cov"
       dev-tooling:
         dependency-type: "development"
         exclude-patterns:
           - "pytest-homeassistant-custom-component"
-          - "pytest"
-          - "pytest-asyncio"
-          - "pytest-cov"
         patterns:
           - "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,10 @@ requires-python = ">=3.14.2"
 authors = [
     { name = "lnagel", email = "lnagel@users.noreply.github.com" }
 ]
-dependencies = [
-    "homeassistant>=2026.3.0",
-]
+dependencies = []
 
 [dependency-groups]
 dev = [
-    "pytest",
-    "pytest-asyncio",
-    "pytest-cov",
     "pytest-homeassistant-custom-component==0.13.355",
     "bump-my-version",
     "diff-cover",

--- a/uv.lock
+++ b/uv.lock
@@ -1104,32 +1104,22 @@ wheels = [
 name = "hass-ufh-controller"
 version = "0.6.0"
 source = { virtual = "." }
-dependencies = [
-    { name = "homeassistant" },
-]
 
 [package.dev-dependencies]
 dev = [
     { name = "bump-my-version" },
     { name = "diff-cover" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "ruff" },
     { name = "ty" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "homeassistant", specifier = ">=2026.3.0" }]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "bump-my-version" },
     { name = "diff-cover" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.355" },
     { name = "ruff" },
     { name = "ty" },


### PR DESCRIPTION
Rolls out the fix validated on hass-komfovent#207.

## What broke

The previous config removed the `ignore` list, and the next dependabot run errored with `No solution found`: it tried to update `pytest` to 9.1.1 while phcc pins `pytest==9.0.3`. Dependabot doesn't check feasibility first — it writes the new version into the manifest and asks uv to resolve. That failure aborts the **entire ecosystem run**, so no PRs were produced at all.

Any directly-declared package that phcc pins exactly is an unsatisfiable update waiting to happen. `ignore` stops the attempt but can't express "don't attempt this, but do accept it when phcc moves it".

## Fix: stop declaring what phcc owns

`homeassistant`, `pytest`, `pytest-asyncio` and `pytest-cov` come out of `pyproject.toml` and arrive transitively at the versions phcc pins. They stay in `uv.lock` at identical versions.

The komfovent job log confirms why this works — dependabot's job definition is `"allowed-updates":[{"dependency-type":"direct","update-type":"all"}]`, so transitive dependencies are never attempted.

phcc is now the only attemptable dependency in the test stack, and whatever it drags along is lockfile fallout inside its own PR. The `ignore` list is no longer needed. Dev tooling keeps its own group and its own PR.

The HA baseline is unaffected — `hacs.json` already declares `"homeassistant": "2026.3.0"`, which is what HACS enforces.

`versioning-strategy` is dropped too: komfovent#205 bumped `pymodbus>=3.10.0` → `>=3.15.0` under `increase-if-necessary` when 3.15.0 already satisfied the floor, so it isn't honoured by dependabot's uv ecosystem.

## Validation on komfovent

Two runs after #207 merged completed successfully with `"ignore-conditions":[]` and no errors. phcc was evaluated in its own group and correctly judged up to date.

Note: dependabot currently reports phcc latest as 0.13.355 although PyPI serves 0.13.356 (released Aug 15, not yanked). Every version it resolved correctly was uploaded on or before Aug 13, so this looks like a stale cached registry index (`"proxy-cached":true`), not a config issue. It should pick up 0.13.356 on a later run.

## Verification

No package versions changed in `uv.lock`. All suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4J3dxHPjuNbfkqibVYunB
